### PR TITLE
Add discreet GitHub repo links to navbar and home hero

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,4 +1,6 @@
 ---
+import { REPO_URL } from "../data/site";
+
 const links = [
   { href: "/", label: "Inicio" },
   { href: "/labs", label: "Aprender" },
@@ -63,6 +65,25 @@ const isActive = (href: string) =>
           ))
         }
       </nav>
+
+      <a
+        href={REPO_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Ver el repositorio en GitHub"
+        class="border-base-700 text-base-400 hover:border-term-green/50 hover:text-base-100 hidden h-9 w-9 shrink-0 items-center justify-center rounded-lg border transition-colors sm:flex"
+      >
+        <svg
+          class="h-4 w-4"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            d="M12 .3a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2c-3.3.7-4-1.6-4-1.6-.6-1.4-1.4-1.8-1.4-1.8-1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.7-1.6-2.7-.3-5.5-1.3-5.5-5.9 0-1.3.5-2.4 1.2-3.2-.1-.3-.5-1.5.1-3.2 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0C17 5 18 5.3 18 5.3c.7 1.7.2 2.9.1 3.2.8.8 1.2 1.9 1.2 3.2 0 4.6-2.8 5.6-5.5 5.9.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6A12 12 0 0 0 12 .3"
+          ></path>
+        </svg>
+      </a>
 
       <button
         type="button"
@@ -206,7 +227,15 @@ const isActive = (href: string) =>
     }
   </nav>
   <div class="border-base-800 mt-auto border-t pt-6 pb-4">
-    <p class="text-base-500 font-mono text-xs">
+    <a
+      href={REPO_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="text-base-400 hover:text-term-green font-mono text-sm transition-colors"
+    >
+      Repositorio en GitHub ↗
+    </a>
+    <p class="text-base-500 mt-4 font-mono text-xs">
       Open Security Labs by VT Security &copy; {new Date().getFullYear()}
     </p>
   </div>

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -1,0 +1,2 @@
+// Datos globales del sitio, una sola fuente de verdad.
+export const REPO_URL = "https://github.com/ValentinTorassa/Open-Security-Labs";

--- a/src/pages/contribuir.astro
+++ b/src/pages/contribuir.astro
@@ -1,11 +1,11 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { contributors, avatarUrl, profileUrl } from "../data/contributors";
+import { REPO_URL as repo } from "../data/site";
 
 // Más commits primero.
 const acks = [...contributors].sort((a, b) => b.commits - a.commits);
 const totalCommits = acks.reduce((n, c) => n + c.commits, 0);
-const repo = "https://github.com/ValentinTorassa/Open-Security-Labs";
 ---
 
 <BaseLayout

--- a/src/pages/crear-lab.astro
+++ b/src/pages/crear-lab.astro
@@ -2,8 +2,8 @@
 import BaseLayout from "../layouts/BaseLayout.astro";
 import Icon from "../components/Icon.astro";
 import { paths } from "../data/paths";
+import { REPO_URL as repo } from "../data/site";
 
-const repo = "https://github.com/ValentinTorassa/Open-Security-Labs";
 const pathOptions = paths.map((path) => ({
   slug: path.slug,
   title: path.title,

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,6 +7,7 @@ import CertCard from "../components/CertCard.astro";
 import Agradecimientos from "../components/Agradecimientos.astro";
 import { paths } from "../data/paths";
 import { portfolioProjects } from "../data/portfolio";
+import { REPO_URL } from "../data/site";
 
 const certifications = (await getCollection("certifications"))
   .map((c) => c.data)
@@ -101,7 +102,6 @@ const trust = [
 
 const youtube = "https://www.youtube.com/@vtcibersecurity";
 const discord = "https://discord.com/invite/z6cr5JF6bJ";
-const repo = "https://github.com/ValentinTorassa/Open-Security-Labs";
 ---
 
 <BaseLayout title="Open Security Labs" width="wide">
@@ -149,7 +149,14 @@ const repo = "https://github.com/ValentinTorassa/Open-Security-Labs";
         class="text-base-400 mt-8 flex flex-wrap gap-x-7 gap-y-3 font-mono text-xs"
       >
         <span><span class="text-term-green">0{paths.length}</span> rutas</span>
-        <span><span class="text-term-green">100%</span> open source</span>
+        <a
+          href={REPO_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="hover:text-term-green transition-colors"
+        >
+          <span class="text-term-green">100%</span> open source ↗
+        </a>
         <span
           ><span class="text-term-green">0</span> login · progreso local</span
         >
@@ -568,7 +575,7 @@ const repo = "https://github.com/ValentinTorassa/Open-Security-Labs";
             Suscribirme
           </a>
           <a
-            href={repo}
+            href={REPO_URL}
             target="_blank"
             rel="noopener noreferrer"
             class="btn-ghost"


### PR DESCRIPTION
## Qué hace

- **Navbar**: botón de ícono de GitHub (mismo estilo que los botones de búsqueda y tema) que linkea al repositorio. En mobile, link de texto en el pie del menú.
- **Home**: el stat `100% open source` del hero ahora es un link directo al repo — visible apenas entrás pero nada invasivo.
- **Refactor**: la URL del repo ahora vive en `src/data/site.ts` (única fuente de verdad) y la importan `index`, `contribuir` y `crear-lab` en lugar de duplicarla por página.

## Verificación

`astro check` 0 errores · `prettier` limpio · `npm run build` 57 páginas OK · links verificados en el HTML generado.