### PR TITLE
Fix critical review findings: robots.txt domain, palette XSS sink, security headers

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://labs.vtsecurity.dev/sitemap-index.xml
+Sitemap: https://securitylabs.valentorassa.com/sitemap-index.xml

--- a/src/components/CommandPalette.astro
+++ b/src/components/CommandPalette.astro
@@ -276,12 +276,23 @@ const items = [...pageItems, ...pathItems, ...labItems];
         li.dataset.idx = String(idx);
         li.className =
           "flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2.5";
-        li.innerHTML = `
-          <span class="shrink-0 rounded border border-base-700 bg-base-800/60 px-1.5 py-0.5 font-mono text-[0.6rem] text-base-400">${it.kind}</span>
-          <span class="min-w-0 flex-1">
-            <span class="block truncate text-sm text-base-100">${it.title}</span>
-            <span class="block truncate font-mono text-[0.7rem] text-base-500">${it.sub}</span>
-          </span>`;
+        // textContent (no innerHTML): title/sub vienen del frontmatter de labs
+        // aportados por PR, no pueden inyectar HTML.
+        const kindEl = document.createElement("span");
+        kindEl.className =
+          "shrink-0 rounded border border-base-700 bg-base-800/60 px-1.5 py-0.5 font-mono text-[0.6rem] text-base-400";
+        kindEl.textContent = it.kind;
+        const bodyEl = document.createElement("span");
+        bodyEl.className = "min-w-0 flex-1";
+        const titleEl = document.createElement("span");
+        titleEl.className = "block truncate text-sm text-base-100";
+        titleEl.textContent = it.title;
+        const subEl = document.createElement("span");
+        subEl.className =
+          "block truncate font-mono text-[0.7rem] text-base-500";
+        subEl.textContent = it.sub;
+        bodyEl.append(titleEl, subEl);
+        li.append(kindEl, bodyEl);
         li.addEventListener("click", () => go(idx));
         li.addEventListener("mousemove", () => {
           active = idx;

--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,22 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "astro",
   "buildCommand": "npm run build",
-  "outputDirectory": "dist"
+  "outputDirectory": "dist",
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=()"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Tres fixes de la revisión completa de calidad/escalabilidad:

1. **robots.txt** apuntaba el sitemap a `labs.vtsecurity.dev` (dominio equivocado); ahora apunta a `securitylabs.valentorassa.com`, que es el `site` real de `astro.config.mjs`.
2. **XSS sink en CommandPalette**: las filas de resultados se armaban con `innerHTML` interpolando `title`/`sub`, que vienen del frontmatter de labs (contenido que llega por PRs de la comunidad) y se renderizan en todas las páginas. Ahora se construyen con `createElement` + `textContent`.
3. **Headers de seguridad** en `vercel.json`: `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy` y `Permissions-Policy`.

Verificación: `astro check` 0 errores, `prettier` limpio, build 57 páginas OK.