### PR TITLE
CI hardening: determinism check, weekly link/a11y health, dependabot, PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+# Qué hace este PR
+
+<!-- Una o dos frases: qué cambia y por qué. -->
+
+## Tipo de cambio
+
+- [ ] Lab nuevo o mejora de contenido
+- [ ] Fix (algo estaba roto)
+- [ ] Feature / UI
+- [ ] Infra / CI / refactor
+
+## Checklist
+
+- [ ] `npm run lint` pasa (prettier + astro check)
+- [ ] `npm run build` pasa
+- [ ] Si es un lab: datos ficticios, defensivo y reproducible (ver `/contribuir`)
+- [ ] Si toca datos (certs, portfolio, paths): los ids referenciados existen (el build lo valida)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      astro:
+        patterns:
+          - "astro*"
+          - "@astrojs/*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,15 @@ jobs:
       - name: Build
         run: npm run build
 
+      # El HTML generado tiene que ser reproducible: dos builds del mismo
+      # commit deben ser byte-idénticos (protege contra uids aleatorios y
+      # órdenes de colección no determinísticos).
+      - name: Determinism check (build twice, diff)
+        run: |
+          cp -r dist /tmp/dist-first
+          npm run build
+          diff -r /tmp/dist-first dist
+
   secrets:
     name: secret scan
     runs-on: ubuntu-latest

--- a/.github/workflows/weekly-health.yml
+++ b/.github/workflows/weekly-health.yml
@@ -1,0 +1,75 @@
+name: Weekly health
+
+# Chequeos que no bloquean PRs pero avisan cuando el contenido se pudre:
+# links externos muertos (esta revisión encontró 11 de una) y regresiones
+# de accesibilidad en el sitio compilado.
+on:
+  schedule:
+    # Lunes 09:00 UTC
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  links:
+    name: link check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Check links in built site
+        uses: lycheeverse/lychee-action@v2
+        with:
+          # 403/429: YouTube y CDNs suelen rebotar bots aunque el link viva.
+          args: >-
+            --no-progress
+            --max-concurrency 4
+            --accept 200..=299,403,429
+            --exclude-path dist/pagefind
+            'dist/**/*.html'
+          fail: true
+
+  a11y:
+    name: accessibility smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Serve dist
+        run: npx --yes serve dist -l 4999 &
+
+      - name: pa11y over representative pages
+        run: |
+          sleep 3
+          npx --yes pa11y-ci \
+            http://localhost:4999/ \
+            http://localhost:4999/labs/ \
+            http://localhost:4999/labs/linux-real/permisos-en-octal/ \
+            http://localhost:4999/certificaciones/ \
+            http://localhost:4999/certificaciones/comptia-security-plus/ \
+            http://localhost:4999/portafolio/ \
+            http://localhost:4999/perfil/


### PR DESCRIPTION
Cierra los gaps de CI/CD de la revisión completa:

- **Check de determinismo en CI**: el job de build ahora compila dos veces y hace `diff -r` — si alguien reintroduce `Math.random()` en build u orden no determinístico, el PR falla (hoy pasa: quedó verificado en el PR #9).
- **Workflow semanal de salud** (`weekly-health.yml`, lunes 09:00 UTC + dispatch manual):
  - **lychee** sobre todo el HTML compilado — la auditoría de hoy encontró 11 links de recursos muertos de una sola vez; esto lo detecta solo. Acepta 403/429 (YouTube/CDNs rebotan bots).
  - **pa11y** sobre 7 páginas representativas (home, labs, un lab, certificaciones, una cert, portafolio, perfil).
- **dependabot** semanal para npm (paquetes de Astro agrupados) y GitHub Actions.
- **Template de PR** con el checklist de lint/build y las reglas de labs.

No toca código del sitio: solo `.github/`.