### PR TITLE
lychee: excluir el canonical de la página 404

### DIFF
--- a/.github/workflows/weekly-health.yml
+++ b/.github/workflows/weekly-health.yml
@@ -36,12 +36,14 @@ jobs:
           # --root-dir resuelve links internos absolutos (/labs/...) contra dist.
           # 403/429: YouTube y CDNs rebotan bots aunque el link viva.
           # 999: LinkedIn responde eso a todo request no-browser.
+          # /404: el canonical de la página 404 devuelve 404 por definición.
           args: >-
             --no-progress
             --max-concurrency 4
             --root-dir ${{ github.workspace }}/dist
             --fallback-extensions html
             --accept 200..=299,403,429,999
+            --exclude '^https://securitylabs\.valentorassa\.com/404'
             'dist/**/*.html'
           fail: true
 


### PR DESCRIPTION
Último falso positivo del link check semanal: `dist/404.html` linkea su propio canonical `/404/`, que devuelve 404 por definición. Verificado localmente con lychee: 0 errores sobre todo dist.