### PR TITLE
fix: preserve spaces around dynamic text

### DIFF
--- a/src/components/Agradecimientos.astro
+++ b/src/components/Agradecimientos.astro
@@ -14,7 +14,7 @@ const totalCommits = acks.reduce((n, c) => n + c.commits, 0);
   </div>
   <p class="text-base-400 mb-10 max-w-2xl text-base leading-relaxed">
     Open Security Labs es open source y existe gracias a quienes escriben labs,
-    corrigen errores y mejoran el material. {acks.length}
+    corrigen errores y mejoran el material. {acks.length}{" "}
     {acks.length === 1 ? "persona" : "personas"} y {totalCommits} commits hasta hoy.
   </p>
 

--- a/src/data/contributors.ts
+++ b/src/data/contributors.ts
@@ -33,6 +33,12 @@ export const contributors: Contributor[] = [
     role: "Autor de lab",
     commits: 1,
   },
+  {
+    github: "CorbalanLucas",
+    name: "Lucas Corbalan",
+    role: "Fixes de espaciado y UI",
+    commits: 1,
+  },
 ];
 
 const byHandle = new Map(contributors.map((c) => [c.github.toLowerCase(), c]));

--- a/src/pages/contribuir.astro
+++ b/src/pages/contribuir.astro
@@ -72,7 +72,7 @@ const totalCommits = acks.reduce((n, c) => n + c.commits, 0);
       <h2>Cómo agregar un lab</h2>
       <p>
         Un lab es un archivo <code>.mdx</code> dentro de la carpeta de su ruta. Por
-        ejemplo, un lab de Linux va en
+        ejemplo, un lab de Linux va en {" "}
         <code>src/content/labs/linux-real/</code>.
       </p>
       <ol>
@@ -85,7 +85,7 @@ const totalCommits = acks.reduce((n, c) => n + c.commits, 0);
           Escribí la lección usando los componentes (Callout, TerminalBlock…).
         </li>
         <li>
-          Verificá con <code>npm run check</code> y mirá el resultado con
+          Verificá con <code>npm run check</code> y mirá el resultado con {" "}
           <code>npm run dev</code>.
         </li>
         <li>Abrí un Pull Request.</li>
@@ -162,9 +162,9 @@ contributor: "TuUsuarioDeGitHub"  # opcional; default: el mantenedor
       </h2>
       <p class="text-base-300 mt-3 leading-relaxed">
         Open Security Labs existe gracias a quienes escriben labs, corrigen
-        errores y mejoran el material. {acks.length}
-        {acks.length === 1 ? "persona" : "personas"} y {totalCommits} commits hasta
-        hoy. Gracias 🙌
+        errores y mejoran el material. {acks.length}{" "}
+        {acks.length === 1 ? "persona" : "personas"} y {totalCommits}{" "}
+        commits hasta hoy. Gracias 🙌
       </p>
 
       <ul class="mt-8 grid gap-4 sm:grid-cols-2">
@@ -207,8 +207,10 @@ contributor: "TuUsuarioDeGitHub"  # opcional; default: el mantenedor
       class="border-base-700 bg-base-850/40 text-base-300 mt-10 rounded-xl border p-6 text-sm"
     >
       <p>
-        Para detalles completos mirá <code class="mono">CONTRIBUTING.md</code>,
-        <code class="mono">AGENTS.md</code> y
+        Para detalles completos mirá <code class="mono">CONTRIBUTING.md</code>, {
+          " "
+        }
+        <code class="mono">AGENTS.md</code> y {" "}
         <code class="mono">SECURITY.md</code> en el repositorio.
       </p>
       <div class="mt-4 flex flex-wrap gap-2">

--- a/src/pages/perfil.astro
+++ b/src/pages/perfil.astro
@@ -172,7 +172,9 @@ const badgesData = JSON.stringify(
     <div class="mt-10 flex items-baseline justify-between gap-3">
       <h2 class="rule-label">Insignias</h2>
       <span class="text-base-400 font-mono text-xs">
-        <span class="text-term-green" data-badges-count>0</span>/{badges.length}
+        <span class="text-term-green" data-badges-count>0</span>/{
+          badges.length
+        }{" "}
         ganadas
       </span>
     </div>
@@ -272,7 +274,7 @@ const badgesData = JSON.stringify(
       >
       </p>
       <p class="text-base-500 mt-3 font-mono text-xs">
-        ¿Empezás de cero?
+        ¿Empezás de cero?{" "}
         <button type="button" data-reset class="text-term-red hover:underline">
           Borrar todo mi progreso
         </button>

--- a/src/pages/rutas/[slug].astro
+++ b/src/pages/rutas/[slug].astro
@@ -129,7 +129,7 @@ const routeJsonLd = [
       <div class="mb-5 flex items-baseline justify-between">
         <h2 class="text-base-50 text-xl font-semibold">Labs de la ruta</h2>
         <span class="text-base-400 font-mono text-xs">
-          {labs.length}
+          {labs.length}{" "}
           {labs.length === 1 ? "lab" : "labs"}
         </span>
       </div>


### PR DESCRIPTION
# Qué hace este PR

Corrige espacios faltantes alrededor de contenido dinámico en varias páginas Astro por ejemplo: "2personas" o "ySECURITY.md". 
Se agregan espacios explícitos con {" "} para conservar el espaciado aún cuando Prettier reformatee los archivos.

## Tipo de cambio

- [ ] Lab nuevo o mejora de contenido
- [ x] Fix (algo estaba roto)
- [ ] Feature / UI
- [ ] Infra / CI / refactor

## Checklist

- [ x] `npm run lint` pasa (prettier + astro check)
- [ x] `npm run build` pasa
- [ ] Si es un lab: datos ficticios, defensivo y reproducible (ver `/contribuir`)
- [ ] Si toca datos (certs, portfolio, paths): los ids referenciados existen (el build lo valida)