### PR TITLE
feat: add optional archive homepage skin

### DIFF
--- a/src/components/Agradecimientos.astro
+++ b/src/components/Agradecimientos.astro
@@ -9,12 +9,13 @@ const initials = (name: string) =>
     .split(" ")
     .slice(0, 2)
     .map((part) => part[0])
-    .join("");
+    .join("")
+    .toUpperCase();
 ---
 
 <section id="agradecimientos" class="scroll-mt-20 py-8">
   <div class="mb-2 flex items-baseline gap-3.5">
-    <span class="text-term-green font-mono text-sm">// 05</span>
+    <span class="text-term-green font-mono text-sm">// 06</span>
     <span class="section-heading-icon" data-section-icon>
       <Icon name="git-branch" size={17} strokeWidth={1.7} />
     </span>

--- a/src/components/Agradecimientos.astro
+++ b/src/components/Agradecimientos.astro
@@ -1,13 +1,23 @@
 ---
 import { contributors, avatarUrl, profileUrl } from "../data/contributors";
+import Icon from "./Icon.astro";
 
 const acks = [...contributors].sort((a, b) => b.commits - a.commits);
 const totalCommits = acks.reduce((n, c) => n + c.commits, 0);
+const initials = (name: string) =>
+  name
+    .split(" ")
+    .slice(0, 2)
+    .map((part) => part[0])
+    .join("");
 ---
 
 <section id="agradecimientos" class="scroll-mt-20 py-8">
   <div class="mb-2 flex items-baseline gap-3.5">
     <span class="text-term-green font-mono text-sm">// 05</span>
+    <span class="section-heading-icon" data-section-icon>
+      <Icon name="git-branch" size={17} strokeWidth={1.7} />
+    </span>
     <h2 class="text-base-50 font-mono text-3xl font-bold tracking-tight">
       Gente que construyó esto
     </h2>
@@ -28,6 +38,9 @@ const totalCommits = acks.reduce((n, c) => n + c.commits, 0);
             rel="noopener noreferrer"
             class="card group flex items-center gap-4 p-4 hover:-translate-y-0.5"
           >
+            <span class="archive-contributor-mark" aria-hidden="true">
+              {initials(c.name)}
+            </span>
             <img
               src={avatarUrl(c.github, 64)}
               alt={`Avatar de ${c.name}`}

--- a/src/components/Agradecimientos.astro
+++ b/src/components/Agradecimientos.astro
@@ -4,13 +4,6 @@ import Icon from "./Icon.astro";
 
 const acks = [...contributors].sort((a, b) => b.commits - a.commits);
 const totalCommits = acks.reduce((n, c) => n + c.commits, 0);
-const initials = (name: string) =>
-  name
-    .split(" ")
-    .slice(0, 2)
-    .map((part) => part[0])
-    .join("")
-    .toUpperCase();
 ---
 
 <section id="agradecimientos" class="scroll-mt-20 py-8">
@@ -39,9 +32,6 @@ const initials = (name: string) =>
             rel="noopener noreferrer"
             class="card group flex items-center gap-4 p-4 hover:-translate-y-0.5"
           >
-            <span class="archive-contributor-mark" aria-hidden="true">
-              {initials(c.name)}
-            </span>
             <img
               src={avatarUrl(c.github, 64)}
               alt={`Avatar de ${c.name}`}

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -106,6 +106,34 @@ const isActive = (href: string) =>
         >
       </button>
 
+      {
+        path === "/" && (
+          <button
+            type="button"
+            data-home-style-toggle
+            aria-label="Activar estilo Archivo operativo"
+            aria-pressed="false"
+            title="Alternar Archivo operativo"
+            class="border-base-700 text-base-400 hover:border-term-green/50 hover:text-base-100 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border transition-colors"
+          >
+            <svg
+              class="h-4 w-4"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.8"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M5 7h14v13H5z" />
+              <path d="M8 7V4h8v3" />
+              <path d="M8 11h8M8 15h8" />
+            </svg>
+          </button>
+        )
+      }
+
       <button
         type="button"
         data-theme-toggle

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -47,7 +47,7 @@ const isActive = (href: string) =>
 
     <div class="flex min-w-0 items-center gap-2">
       <!-- Nav Desktop -->
-      <nav class="hidden items-center gap-2 lg:flex" aria-label="Principal">
+      <nav class="hidden items-center gap-2 xl:flex" aria-label="Principal">
         {
           links.map((l) => (
             <a
@@ -175,7 +175,7 @@ const isActive = (href: string) =>
         aria-label="Abrir menú"
         aria-expanded="false"
         aria-controls="mobile-menu"
-        class="border-base-700 text-base-400 hover:border-term-green/50 hover:text-base-100 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border transition-colors lg:hidden"
+        class="border-base-700 text-base-400 hover:border-term-green/50 hover:text-base-100 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border transition-colors xl:hidden"
       >
         <svg
           class="h-4 w-4"
@@ -201,7 +201,7 @@ const isActive = (href: string) =>
 <div
   id="mobile-menu"
   data-mobile-menu
-  class="bg-base-950/95 fixed inset-0 z-[100] flex hidden flex-col px-5 py-5 backdrop-blur-md transition-opacity lg:hidden"
+  class="bg-base-950/95 fixed inset-0 z-[100] flex hidden flex-col px-5 py-5 backdrop-blur-md transition-opacity xl:hidden"
   style="height: 100dvh;"
 >
   <div class="flex items-center justify-between">

--- a/src/components/PathCard.astro
+++ b/src/components/PathCard.astro
@@ -16,13 +16,145 @@ const { path, labCount, labIds = [] } = Astro.props;
   class="card group relative flex flex-col overflow-hidden p-5 hover:-translate-y-0.5"
   style={`--accent: ${path.accent}`}
   data-path-card
+  data-path-slug={path.slug}
 >
   <div class="flex items-center justify-between gap-3">
     <span
       class="flex h-10 w-10 items-center justify-center rounded-lg border"
       style="border-color: color-mix(in srgb, var(--accent) 40%, transparent); color: var(--accent); background: color-mix(in srgb, var(--accent) 8%, transparent)"
     >
-      <Icon name={path.icon} size={20} />
+      <span class="path-icon-default flex items-center justify-center">
+        <Icon name={path.icon} size={20} />
+      </span>
+      {
+        path.slug === "redes-internet" && (
+          <svg
+            class="archive-route-art"
+            viewBox="0 0 120 120"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.25"
+            aria-hidden="true"
+          >
+            <circle cx="60" cy="60" r="44" opacity="0.32" />
+            <circle cx="60" cy="60" r="24" opacity="0.5" />
+            <path d="m60 16 34 22 6 40-40 26-40-26 6-40Z" opacity="0.72" />
+            <path
+              d="M60 16v44m34-22L60 60m40 18L60 60m0 44V60M20 78l40-18M26 38l34 22"
+              opacity="0.52"
+            />
+            <circle cx="60" cy="60" r="8" />
+            <g fill="currentColor" stroke="none">
+              <circle cx="60" cy="16" r="2.6" />
+              <circle cx="94" cy="38" r="2.6" />
+              <circle cx="100" cy="78" r="2.6" />
+              <circle cx="60" cy="104" r="2.6" />
+              <circle cx="20" cy="78" r="2.6" />
+              <circle cx="26" cy="38" r="2.6" />
+              <circle cx="60" cy="60" r="3.4" />
+            </g>
+          </svg>
+        )
+      }
+      {
+        path.slug === "cloud-produccion" && (
+          <svg
+            class="archive-route-art"
+            viewBox="0 0 120 120"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.25"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M24 48h66c8 0 14-6 14-13s-6-13-14-13c-2 0-4 .4-6 1C80 14 72 9 62 9c-13 0-23 9-25 21-3-2-6-3-10-3-8 0-14 5-14 11s5 10 11 10Z" />
+            <path
+              d="M60 48v18M26 66h68M26 66v14m34-14v14m34-14v14"
+              opacity="0.7"
+            />
+            <rect x="14" y="80" width="24" height="22" />
+            <rect x="48" y="80" width="24" height="22" />
+            <rect x="82" y="80" width="24" height="22" />
+            <path
+              d="M19 88h10m-10 6h7m27-6h10m-10 6h7m27-6h10m-10 6h7"
+              opacity="0.68"
+            />
+            <g fill="currentColor" stroke="none">
+              <circle cx="33" cy="94" r="1.8" />
+              <circle cx="67" cy="94" r="1.8" />
+              <circle cx="101" cy="94" r="1.8" />
+            </g>
+          </svg>
+        )
+      }
+      {
+        path.slug === "ciberseguridad" && (
+          <svg
+            class="archive-route-art"
+            viewBox="0 0 120 120"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.25"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="m60 9 39 15v29c0 25-15 43-39 57-24-14-39-32-39-57V24Z" />
+            <path
+              d="m60 20 28 11v22c0 18-10 32-28 44-18-12-28-26-28-44V31Z"
+              opacity="0.48"
+            />
+            <circle cx="60" cy="55" r="15" />
+            <circle cx="60" cy="55" r="5" />
+            <path
+              d="M60 32v10m0 26v12M37 55h10m26 0h10M43 38l7 7m20 20 7 7m0-34-7 7M50 65l-7 7"
+              opacity="0.72"
+            />
+            <path d="m53 55 5 5 10-12" stroke-width="1.8" />
+            <g fill="currentColor" stroke="none">
+              <circle cx="60" cy="32" r="2" />
+              <circle cx="83" cy="55" r="2" />
+              <circle cx="60" cy="80" r="2" />
+              <circle cx="37" cy="55" r="2" />
+            </g>
+          </svg>
+        )
+      }
+      {
+        path.slug === "devsecops-agentes" && (
+          <svg
+            class="archive-route-art"
+            viewBox="0 0 120 120"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.25"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <rect x="17" y="25" width="86" height="70" rx="20" opacity="0.5" />
+            <path d="M17 60h86M38 25v70m44-70v70" opacity="0.68" />
+            <rect x="50" y="45" width="20" height="30" />
+            <path d="m55 59 4 4 7-9" stroke-width="1.8" />
+            <path d="m26 25 5-5 5 5m58 70-5 5-5-5" />
+            <g fill="var(--archive-surface, #0d0e0c)" stroke="currentColor">
+              <circle cx="17" cy="60" r="5" />
+              <circle cx="38" cy="25" r="5" />
+              <circle cx="82" cy="25" r="5" />
+              <circle cx="103" cy="60" r="5" />
+              <circle cx="82" cy="95" r="5" />
+              <circle cx="38" cy="95" r="5" />
+            </g>
+            <g fill="currentColor" stroke="none">
+              <circle cx="17" cy="60" r="1.8" />
+              <circle cx="38" cy="25" r="1.8" />
+              <circle cx="82" cy="25" r="1.8" />
+              <circle cx="103" cy="60" r="1.8" />
+              <circle cx="82" cy="95" r="1.8" />
+              <circle cx="38" cy="95" r="1.8" />
+            </g>
+          </svg>
+        )
+      }
     </span>
     <span class="text-base-400 flex items-center gap-2 font-mono text-xs">
       <span>Ruta {String(path.order).padStart(2, "0")}</span>
@@ -96,6 +228,12 @@ const { path, labCount, labIds = [] } = Astro.props;
     )
   }
 </a>
+
+<style>
+  .archive-route-art {
+    display: none;
+  }
+</style>
 
 <script>
   import { countDone, onProgress } from "../scripts/progress";

--- a/src/components/PathCard.astro
+++ b/src/components/PathCard.astro
@@ -36,22 +36,16 @@ const { path, labCount, labIds = [] } = Astro.props;
             stroke-width="1.25"
             aria-hidden="true"
           >
-            <circle cx="60" cy="60" r="44" opacity="0.32" />
-            <circle cx="60" cy="60" r="24" opacity="0.5" />
-            <path d="m60 16 34 22 6 40-40 26-40-26 6-40Z" opacity="0.72" />
-            <path
-              d="M60 16v44m34-22L60 60m40 18L60 60m0 44V60M20 78l40-18M26 38l34 22"
-              opacity="0.52"
-            />
-            <circle cx="60" cy="60" r="8" />
+            <path d="M60 60V24M60 60 25 90m35-30 35 30" opacity="0.65" />
+            <circle cx="60" cy="22" r="11" />
+            <circle cx="23" cy="92" r="11" />
+            <circle cx="97" cy="92" r="11" />
+            <circle cx="60" cy="60" r="7" />
             <g fill="currentColor" stroke="none">
-              <circle cx="60" cy="16" r="2.6" />
-              <circle cx="94" cy="38" r="2.6" />
-              <circle cx="100" cy="78" r="2.6" />
-              <circle cx="60" cy="104" r="2.6" />
-              <circle cx="20" cy="78" r="2.6" />
-              <circle cx="26" cy="38" r="2.6" />
-              <circle cx="60" cy="60" r="3.4" />
+              <circle cx="60" cy="22" r="2.4" />
+              <circle cx="23" cy="92" r="2.4" />
+              <circle cx="97" cy="92" r="2.4" />
+              <circle cx="60" cy="60" r="2.8" />
             </g>
           </svg>
         )
@@ -98,24 +92,8 @@ const { path, labCount, labIds = [] } = Astro.props;
             stroke-linejoin="round"
             aria-hidden="true"
           >
-            <path d="m60 9 39 15v29c0 25-15 43-39 57-24-14-39-32-39-57V24Z" />
-            <path
-              d="m60 20 28 11v22c0 18-10 32-28 44-18-12-28-26-28-44V31Z"
-              opacity="0.48"
-            />
-            <circle cx="60" cy="55" r="15" />
-            <circle cx="60" cy="55" r="5" />
-            <path
-              d="M60 32v10m0 26v12M37 55h10m26 0h10M43 38l7 7m20 20 7 7m0-34-7 7M50 65l-7 7"
-              opacity="0.72"
-            />
-            <path d="m53 55 5 5 10-12" stroke-width="1.8" />
-            <g fill="currentColor" stroke="none">
-              <circle cx="60" cy="32" r="2" />
-              <circle cx="83" cy="55" r="2" />
-              <circle cx="60" cy="80" r="2" />
-              <circle cx="37" cy="55" r="2" />
-            </g>
+            <path d="m60 8 44 17v31c0 25-17 43-44 57-27-14-44-32-44-57V25Z" />
+            <path d="m40 58 12 12 28-31" stroke-width="2" />
           </svg>
         )
       }
@@ -131,27 +109,15 @@ const { path, labCount, labIds = [] } = Astro.props;
             stroke-linejoin="round"
             aria-hidden="true"
           >
-            <rect x="17" y="25" width="86" height="70" rx="20" opacity="0.5" />
-            <path d="M17 60h86M38 25v70m44-70v70" opacity="0.68" />
-            <rect x="50" y="45" width="20" height="30" />
-            <path d="m55 59 4 4 7-9" stroke-width="1.8" />
-            <path d="m26 25 5-5 5 5m58 70-5 5-5-5" />
-            <g fill="var(--archive-surface, #0d0e0c)" stroke="currentColor">
-              <circle cx="17" cy="60" r="5" />
-              <circle cx="38" cy="25" r="5" />
-              <circle cx="82" cy="25" r="5" />
-              <circle cx="103" cy="60" r="5" />
-              <circle cx="82" cy="95" r="5" />
-              <circle cx="38" cy="95" r="5" />
-            </g>
-            <g fill="currentColor" stroke="none">
-              <circle cx="17" cy="60" r="1.8" />
-              <circle cx="38" cy="25" r="1.8" />
-              <circle cx="82" cy="25" r="1.8" />
-              <circle cx="103" cy="60" r="1.8" />
-              <circle cx="82" cy="95" r="1.8" />
-              <circle cx="38" cy="95" r="1.8" />
-            </g>
+            <path d="M16 60c12-25 29-27 44 0s32 25 44 0c-12-25-29-27-44 0S28 85 16 60Z" />
+            <rect
+              x="50"
+              y="50"
+              width="20"
+              height="20"
+              fill="var(--archive-surface, #0d0e0c)"
+            />
+            <path d="m55 60 4 4 7-9" stroke-width="1.8" />
           </svg>
         )
       }

--- a/src/components/PathCard.astro
+++ b/src/components/PathCard.astro
@@ -109,27 +109,26 @@ const { path, labCount, labIds = [] } = Astro.props;
             stroke-linejoin="round"
             aria-hidden="true"
           >
-            <path d="M16 60c12-25 29-27 44 0s32 25 44 0c-12-25-29-27-44 0S28 85 16 60Z" />
             <rect
-              x="42"
-              y="40"
-              width="36"
-              height="36"
-              rx="3"
+              x="28"
+              y="32"
+              width="64"
+              height="56"
+              rx="4"
               fill="var(--archive-surface, #0d0e0c)"
             />
-            <path d="M60 40V30" />
+            <path d="M28 48h-8v24h8m64-24h8v24h-8M60 32V20" />
             <circle
               cx="60"
-              cy="27"
-              r="3"
+              cy="16"
+              r="4"
               fill="var(--archive-surface, #0d0e0c)"
             />
             <g fill="currentColor" stroke="none">
-              <circle cx="52" cy="54" r="2.2" />
-              <circle cx="68" cy="54" r="2.2" />
+              <circle cx="46" cy="54" r="3" />
+              <circle cx="74" cy="54" r="3" />
             </g>
-            <path d="M51 66h18" />
+            <path d="M43 72h34" />
           </svg>
         )
       }

--- a/src/components/PathCard.astro
+++ b/src/components/PathCard.astro
@@ -111,13 +111,25 @@ const { path, labCount, labIds = [] } = Astro.props;
           >
             <path d="M16 60c12-25 29-27 44 0s32 25 44 0c-12-25-29-27-44 0S28 85 16 60Z" />
             <rect
-              x="50"
-              y="50"
-              width="20"
-              height="20"
+              x="42"
+              y="40"
+              width="36"
+              height="36"
+              rx="3"
               fill="var(--archive-surface, #0d0e0c)"
             />
-            <path d="m55 60 4 4 7-9" stroke-width="1.8" />
+            <path d="M60 40V30" />
+            <circle
+              cx="60"
+              cy="27"
+              r="3"
+              fill="var(--archive-surface, #0d0e0c)"
+            />
+            <g fill="currentColor" stroke="none">
+              <circle cx="52" cy="54" r="2.2" />
+              <circle cx="68" cy="54" r="2.2" />
+            </g>
+            <path d="M51 66h18" />
           </svg>
         )
       }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -743,6 +743,11 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
 
   :root[data-home-style="archive"] {
     color-scheme: dark;
+    --archive-surface: #0d0e0c;
+    --archive-surface-raised: #11120f;
+    --archive-line: #363930;
+    --archive-copy: #9b9e95;
+    --archive-meta: #85887f;
     --color-base-950: #090a08 !important;
     --color-base-900: #0d0e0c !important;
     --color-base-850: #11120f !important;
@@ -775,7 +780,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   }
 
   :root[data-home-style="archive"] body > header > div {
-    height: 4.5rem;
+    height: 4rem;
   }
 
   :root[data-home-style="archive"] body > header img,
@@ -785,9 +790,9 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   }
 
   :root[data-home-style="archive"] body > header nav a {
-    color: #8d9087;
-    font-size: 0.65rem;
-    letter-spacing: 0.05em;
+    color: #a8aaa2;
+    font-size: 0.7rem;
+    letter-spacing: 0.04em;
     text-transform: uppercase;
   }
 
@@ -797,6 +802,29 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
 
   :root[data-home-style="archive"] [data-theme-toggle] {
     display: none !important;
+  }
+
+  :root[data-home-style="archive"] [data-mobile-menu] {
+    background: rgba(9, 10, 8, 0.98) !important;
+    backdrop-filter: none;
+  }
+
+  :root[data-home-style="archive"] [data-mobile-menu] :is(a, button, img) {
+    border-radius: 0 !important;
+  }
+
+  :root[data-home-style="archive"] [data-mobile-menu] nav {
+    gap: 0;
+    margin-top: 3rem;
+    border-top: 1px solid var(--archive-line);
+  }
+
+  :root[data-home-style="archive"] [data-mobile-menu] nav a {
+    padding: 1rem 0;
+    border-bottom: 1px solid var(--archive-line);
+    font-size: 0.78rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
   }
 
   :root[data-home-style="archive"] .section-heading-icon {
@@ -817,9 +845,9 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   :root[data-home-style="archive"] .hero-frame {
     grid-template-columns: minmax(0, 1.12fr) minmax(330px, 0.88fr) !important;
     gap: clamp(3rem, 6vw, 5.5rem) !important;
-    min-height: 650px;
+    min-height: 610px;
     margin-top: 1rem !important;
-    padding: 4.5rem 0 5rem !important;
+    padding: 4rem 0 4.5rem !important;
     overflow: visible;
     border: 0;
     border-top: 1px solid #44473f;
@@ -894,7 +922,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     --color-term-blue: #2c5149 !important;
     --color-term-amber: #7a3d2e !important;
     position: relative;
-    min-height: 480px;
+    min-height: 440px;
     overflow: hidden;
     border: 1px solid #5e5037;
     border-radius: 0 !important;
@@ -942,11 +970,11 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
 
   :root[data-home-style="archive"] .terminal-object__body {
     display: flex;
-    min-height: 420px;
+    min-height: 380px;
     flex-direction: column;
     justify-content: center;
     background: transparent !important;
-    font-size: 0.73rem !important;
+    font-size: 0.76rem !important;
     line-height: 1.9 !important;
   }
 
@@ -969,8 +997,8 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   }
 
   :root[data-home-style="archive"] main > section:not(#top) {
-    padding-top: 4.25rem !important;
-    padding-bottom: 4.25rem !important;
+    padding-top: 3.75rem !important;
+    padding-bottom: 3.75rem !important;
   }
 
   :root[data-home-style="archive"]
@@ -1001,6 +1029,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     font-family: Georgia, "Times New Roman", serif !important;
     font-size: clamp(2rem, 4vw, 3rem) !important;
     font-weight: 400 !important;
+    line-height: 1 !important;
     letter-spacing: -0.035em !important;
   }
 
@@ -1031,16 +1060,16 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     > div:first-child
     + p {
     max-width: 700px;
-    margin-bottom: 2.5rem !important;
-    color: #8d9087;
+    margin-bottom: 2.25rem !important;
+    color: var(--archive-copy);
     font-size: 0.85rem;
     line-height: 1.65;
   }
 
   :root[data-home-style="archive"] main .card {
-    border-color: #2f322c;
+    border-color: var(--archive-line);
     border-radius: 0 !important;
-    background: #0d0e0c;
+    background: var(--archive-surface);
     box-shadow: none !important;
   }
 
@@ -1048,9 +1077,10 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     display: none;
   }
 
-  :root[data-home-style="archive"] main .card:hover {
-    border-color: color-mix(in srgb, var(--accent, #d7ff64) 55%, #44473f);
-    background: #11120f;
+  :root[data-home-style="archive"] main a.card:is(:hover, :focus-visible) {
+    outline: 1px solid color-mix(in srgb, var(--accent, #d7ff64) 55%, #44473f);
+    outline-offset: -1px;
+    background: var(--archive-surface-raised);
     transform: none !important;
   }
 
@@ -1066,7 +1096,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   }
 
   :root[data-home-style="archive"] [data-trust-card] {
-    min-height: 145px;
+    min-height: 128px;
     padding: 1.2rem !important;
     border: 0;
     border-right: 1px solid #44473f;
@@ -1171,8 +1201,9 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     [data-trust-card]
     > span:last-child
     > span:last-child {
-    color: #7f8279;
-    font-size: 0.68rem;
+    color: var(--archive-copy);
+    font-size: 0.75rem;
+    line-height: 1.55;
   }
 
   :root[data-home-style="archive"] #metodo > .grid {
@@ -1181,7 +1212,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   }
 
   :root[data-home-style="archive"] [data-method-card] {
-    min-height: 285px;
+    min-height: 260px;
     padding: 1rem !important;
     border: 0 !important;
   }
@@ -1203,7 +1234,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     width: 88px;
     height: 88px;
     place-items: center;
-    margin: 1.7rem auto;
+    margin: 1.4rem auto;
     border: 1px solid currentColor;
   }
 
@@ -1310,14 +1341,14 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
 
   :root[data-home-style="archive"] [data-method-card] > div:nth-child(2) {
     font-family: Georgia, "Times New Roman", serif !important;
-    font-size: 0.95rem;
+    font-size: 1rem;
     font-weight: 400;
   }
 
   :root[data-home-style="archive"] [data-method-card] > p {
-    color: #777a71;
-    font-size: 0.67rem;
-    line-height: 1.55;
+    color: var(--archive-copy);
+    font-size: 0.75rem;
+    line-height: 1.6;
   }
 
   :root[data-home-style="archive"] #rutas > .grid {
@@ -1326,7 +1357,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   }
 
   :root[data-home-style="archive"] #rutas [data-path-card] {
-    min-height: 420px;
+    min-height: 390px;
     padding: 1rem !important;
     border: 0;
     background: #0d0e0c;
@@ -1349,7 +1380,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     display: block;
     width: 120px;
     height: 120px;
-    margin: 2.2rem auto;
+    margin: 1.55rem auto;
     border: 1px solid var(--accent) !important;
     border-radius: 0 !important;
     background: transparent !important;
@@ -1388,8 +1419,8 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     grid-row: 1;
     width: 100%;
     justify-content: space-between;
-    color: #777a71;
-    font-size: 0.48rem;
+    color: var(--archive-meta);
+    font-size: 0.625rem;
   }
 
   :root[data-home-style="archive"]
@@ -1548,7 +1579,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     > span:first-child {
     width: 100px;
     height: 82px;
-    margin-top: 3.8rem;
+    margin-top: 3.15rem;
   }
 
   :root[data-home-style="archive"]
@@ -1628,10 +1659,10 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
 
   :root[data-home-style="archive"] #rutas [data-path-card] h3 + p {
     min-height: 3.2em;
-    color: #9b9e95;
-    font:
-      0.72rem/1.5 Georgia,
-      serif;
+    color: var(--archive-copy);
+    font-family: inherit;
+    font-size: 0.75rem;
+    line-height: 1.55;
   }
 
   :root[data-home-style="archive"]
@@ -1642,8 +1673,8 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     border-color: #2f322c;
     border-radius: 0;
     background: transparent;
-    color: #72766c;
-    font-size: 0.5rem;
+    color: var(--archive-meta);
+    font-size: 0.625rem;
   }
 
   :root[data-home-style="archive"]
@@ -1651,7 +1682,8 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     [data-path-card]
     > div:nth-of-type(3) {
     border-color: #2f322c;
-    font-size: 0.55rem;
+    color: var(--archive-meta);
+    font-size: 0.625rem;
   }
 
   :root[data-home-style="archive"] #certificaciones > .grid {
@@ -1660,7 +1692,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   }
 
   :root[data-home-style="archive"] #certificaciones .card {
-    min-height: 310px;
+    min-height: 290px;
     padding: 1rem !important;
     border: 0;
   }
@@ -1670,8 +1702,8 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     .card
     > div:first-child
     > span {
-    width: 4.4rem;
-    height: 4.4rem;
+    width: 4rem;
+    height: 4rem;
     border-radius: 0 !important;
     background: transparent;
     box-shadow: none;
@@ -1684,9 +1716,9 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   }
 
   :root[data-home-style="archive"] #certificaciones .card h3 + p {
-    color: #7f8279;
-    font-size: 0.68rem;
-    line-height: 1.55;
+    color: var(--archive-copy);
+    font-size: 0.75rem;
+    line-height: 1.6;
   }
 
   :root[data-home-style="archive"] #certificaciones .card > div:nth-of-type(2) {
@@ -1702,13 +1734,14 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     border: 0;
     border-radius: 0;
     background: #11120f;
-    font-size: 0.5rem;
+    color: var(--archive-meta);
+    font-size: 0.625rem;
   }
 
   :root[data-home-style="archive"] #certificaciones .card > div:last-child {
     border-color: #2f322c;
-    color: #72766c;
-    font-size: 0.53rem;
+    color: var(--archive-meta);
+    font-size: 0.625rem;
   }
 
   :root[data-home-style="archive"] #portafolio > div:nth-of-type(2) {
@@ -1716,7 +1749,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   }
 
   :root[data-home-style="archive"] [data-portfolio-project] {
-    min-height: 120px;
+    min-height: 104px;
     padding: 1rem !important;
     border: 0;
     border-bottom: 1px solid #44473f;
@@ -1741,9 +1774,9 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     [data-portfolio-project]
     > span:last-child
     > span:last-child {
-    color: #777a71;
-    font-size: 0.67rem;
-    line-height: 1.5;
+    color: var(--archive-copy);
+    font-size: 0.75rem;
+    line-height: 1.6;
   }
 
   :root[data-home-style="archive"] #portafolio .btn-primary {
@@ -1753,7 +1786,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   }
 
   :root[data-home-style="archive"] [data-portfolio-roadmap] {
-    min-height: 430px;
+    min-height: 390px;
     border-color: #5e5037 !important;
     border-radius: 0 !important;
     background: #c7a76a !important;
@@ -1791,7 +1824,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   :root[data-home-style="archive"] [data-portfolio-roadmap] > div:last-child {
     z-index: 1;
     display: flex;
-    min-height: 370px;
+    min-height: 330px;
     flex-direction: column;
   }
 
@@ -1812,7 +1845,8 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
 
   :root[data-home-style="archive"] [data-portfolio-roadmap] h3 + p {
     color: #3f3829 !important;
-    font-size: 0.69rem;
+    font-size: 0.75rem;
+    line-height: 1.55;
   }
 
   :root[data-home-style="archive"]
@@ -1839,7 +1873,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   }
 
   :root[data-home-style="archive"] [data-audience-card] {
-    min-height: 150px;
+    min-height: 126px;
     padding: 1rem !important;
     border: 0;
   }
@@ -1863,9 +1897,9 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   }
 
   :root[data-home-style="archive"] [data-audience-card] p {
-    color: #777a71;
-    font-size: 0.67rem;
-    line-height: 1.5;
+    color: var(--archive-copy);
+    font-size: 0.75rem;
+    line-height: 1.6;
   }
 
   :root[data-home-style="archive"] #agradecimientos > ul {
@@ -1877,7 +1911,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   }
 
   :root[data-home-style="archive"] #agradecimientos li .card {
-    min-height: 104px;
+    min-height: 88px;
     padding: 0.9rem !important;
     border: 0;
     border-right: 1px solid #2f322c;
@@ -1894,21 +1928,23 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     height: 2.7rem;
     flex: none;
     place-items: center;
-    border: 1px solid #d7ff64;
+    border: 1px solid #5a5d53;
+    background: rgba(215, 255, 100, 0.04);
     color: #d7ff64;
-    font: 700 0.52rem var(--font-mono);
+    font: 700 0.68rem var(--font-mono);
+    letter-spacing: 0.04em;
   }
 
   :root[data-home-style="archive"] #agradecimientos li .card p:first-child {
     font-family: Georgia, "Times New Roman", serif;
-    font-size: 0.78rem;
+    font-size: 0.84rem;
     font-weight: 400;
   }
 
   :root[data-home-style="archive"] #agradecimientos li .card p:last-child {
     margin-top: 0.25rem;
-    color: #777a71;
-    font-size: 0.6rem;
+    color: var(--archive-copy);
+    font-size: 0.68rem;
   }
 
   :root[data-home-style="archive"] #comunidad {
@@ -1974,7 +2010,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   }
 
   :root[data-home-style="archive"] body > footer {
-    margin-top: 3rem !important;
+    margin-top: 2rem !important;
     border-color: #2f322c;
     background: #0d0e0c;
   }
@@ -2003,25 +2039,25 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
 
   @media (max-width: 640px) {
     :root[data-home-style="archive"] main > section:not(#top) {
-      padding-top: 3.5rem !important;
-      padding-bottom: 3.5rem !important;
+      padding-top: 3rem !important;
+      padding-bottom: 3rem !important;
     }
 
     :root[data-home-style="archive"] .hero-frame {
       margin-inline: -1.25rem;
-      padding: 3.5rem 1.25rem 4rem !important;
+      padding: 3.25rem 1.25rem 3.5rem !important;
       border-right: 0;
       border-left: 0;
     }
 
     :root[data-home-style="archive"] .terminal-object {
-      min-height: 440px;
+      min-height: 400px;
       box-shadow: 9px 9px 0 #171914;
     }
 
     :root[data-home-style="archive"] .terminal-object__body {
-      min-height: 380px;
-      font-size: 0.65rem !important;
+      min-height: 340px;
+      font-size: 0.7rem !important;
     }
 
     :root[data-home-style="archive"] [data-trust-card] {
@@ -2031,15 +2067,44 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     }
 
     :root[data-home-style="archive"] [data-method-card] {
-      min-height: 250px;
+      min-height: 225px;
+    }
+
+    :root[data-home-style="archive"]
+      [data-method-card]
+      > div:first-child
+      > span:first-child {
+      margin-block: 1.15rem;
     }
 
     :root[data-home-style="archive"] #rutas [data-path-card] {
-      min-height: 390px;
+      min-height: 350px;
+    }
+
+    :root[data-home-style="archive"]
+      #rutas
+      [data-path-card]
+      > div:first-child
+      > span:first-child {
+      margin-block: 1.25rem;
+    }
+
+    :root[data-home-style="archive"]
+      #rutas
+      > .grid
+      > [data-path-card]:nth-of-type(5)
+      > div:first-child
+      > span:first-child {
+      margin-top: 2.9rem;
+      margin-bottom: 1.25rem;
     }
 
     :root[data-home-style="archive"] [data-portfolio-roadmap] {
-      min-height: 400px;
+      min-height: 360px;
+    }
+
+    :root[data-home-style="archive"] [data-portfolio-roadmap] > div:last-child {
+      min-height: 300px;
     }
 
     :root[data-home-style="archive"] [data-community-panel] {
@@ -2047,6 +2112,11 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
       padding: 2rem 1.25rem !important;
       border-right: 0;
       border-left: 0;
+    }
+
+    :root[data-home-style="archive"] [data-community-panel] img {
+      width: 6rem;
+      height: 6rem;
     }
 
     :root[data-home-style="archive"] #agradecimientos > ul {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1744,7 +1744,8 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
 
   :root[data-home-style="archive"]
     #rutas
-    [data-path-card]:is(
+    > .grid
+    > [data-path-card]:is(
       [data-path-slug="redes-internet"],
       [data-path-slug="cloud-produccion"],
       [data-path-slug="ciberseguridad"],
@@ -1763,7 +1764,8 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
 
   :root[data-home-style="archive"]
     #rutas
-    [data-path-card]:is(
+    > .grid
+    > [data-path-card]:is(
       [data-path-slug="redes-internet"],
       [data-path-slug="cloud-produccion"],
       [data-path-slug="ciberseguridad"],
@@ -1773,7 +1775,8 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     > span:first-child::before,
   :root[data-home-style="archive"]
     #rutas
-    [data-path-card]:is(
+    > .grid
+    > [data-path-card]:is(
       [data-path-slug="redes-internet"],
       [data-path-slug="cloud-produccion"],
       [data-path-slug="ciberseguridad"],

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1484,7 +1484,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     [data-path-card]
     > div:first-child
     > span:first-child
-    svg {
+    .path-icon-default {
     display: none;
   }
 
@@ -1740,6 +1740,55 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     left: 50%;
     width: 1px;
     background: currentColor;
+  }
+
+  :root[data-home-style="archive"]
+    #rutas
+    [data-path-card]:is(
+      [data-path-slug="redes-internet"],
+      [data-path-slug="cloud-produccion"],
+      [data-path-slug="ciberseguridad"],
+      [data-path-slug="devsecops-agentes"]
+    )
+    > div:first-child
+    > span:first-child {
+    width: 120px;
+    height: 120px;
+    margin: 1.55rem auto;
+    border: 0 !important;
+    border-radius: 0 !important;
+    background: transparent !important;
+    transform: none;
+  }
+
+  :root[data-home-style="archive"]
+    #rutas
+    [data-path-card]:is(
+      [data-path-slug="redes-internet"],
+      [data-path-slug="cloud-produccion"],
+      [data-path-slug="ciberseguridad"],
+      [data-path-slug="devsecops-agentes"]
+    )
+    > div:first-child
+    > span:first-child::before,
+  :root[data-home-style="archive"]
+    #rutas
+    [data-path-card]:is(
+      [data-path-slug="redes-internet"],
+      [data-path-slug="cloud-produccion"],
+      [data-path-slug="ciberseguridad"],
+      [data-path-slug="devsecops-agentes"]
+    )
+    > div:first-child
+    > span:first-child::after {
+    display: none;
+  }
+
+  :root[data-home-style="archive"] #rutas .archive-route-art {
+    display: block;
+    width: 100%;
+    height: 100%;
+    overflow: visible;
   }
 
   :root[data-home-style="archive"] #rutas [data-path-card] h3 {
@@ -2196,16 +2245,6 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
       > div:first-child
       > span:first-child {
       margin-block: 1.25rem;
-    }
-
-    :root[data-home-style="archive"]
-      #rutas
-      > .grid
-      > [data-path-card]:nth-of-type(5)
-      > div:first-child
-      > span:first-child {
-      margin-top: 2.9rem;
-      margin-bottom: 1.25rem;
     }
 
     :root[data-home-style="archive"] [data-portfolio-roadmap] {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -123,7 +123,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   >
   </div>
 
-  <!-- ===================== HERO : TERMINAL ===================== -->
+  <!-- ===================== HERO ===================== -->
   <section
     id="top"
     class="hero-frame mt-4 grid items-center gap-8 px-4 py-5 sm:mt-6 sm:px-6 sm:py-7 lg:grid-cols-[1.02fr_0.98fr] lg:px-8 lg:py-8"
@@ -182,7 +182,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
       </div>
     </div>
 
-    <!-- Terminal como objeto principal del hero. -->
+    <!-- La vista actual usa terminal; Archivo operativo muestra un mapa. -->
     <div class="terminal-object overflow-hidden rounded-xl">
       <div
         class="terminal-object__header border-base-700 flex items-center justify-between gap-4 border-b px-3.5 py-3"
@@ -237,6 +237,46 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
           > ./empezar.sh<span
             class="bg-term-green ml-0.5 inline-block h-4 w-2 [animation:vtBlink_1s_step-end_infinite] align-[-3px]"
           ></span>
+        </div>
+      </div>
+
+      <div class="archive-system-map" aria-hidden="true">
+        <div class="archive-system-map__header">
+          <span>OSL / system map</span>
+          <span>index 01—06</span>
+        </div>
+        <div class="archive-system-map__diagram">
+          <svg viewBox="0 0 520 280" role="presentation">
+            <g class="archive-system-map__orbits">
+              <circle cx="260" cy="140" r="94"></circle>
+              <circle cx="260" cy="140" r="58"></circle>
+              <path d="M260 140 105 54M260 140 260 30M260 140 415 54"></path>
+              <path d="M260 140 105 226M260 140 260 250M260 140 415 226"></path>
+            </g>
+            <g class="archive-system-map__nodes">
+              <circle cx="105" cy="54" r="7"></circle>
+              <rect x="253" y="23" width="14" height="14"></rect>
+              <circle cx="415" cy="54" r="7"></circle>
+              <rect x="98" y="219" width="14" height="14"></rect>
+              <circle cx="260" cy="250" r="7"></circle>
+              <rect x="408" y="219" width="14" height="14"></rect>
+            </g>
+            <g class="archive-system-map__core">
+              <rect x="226" y="106" width="68" height="68"></rect>
+              <rect x="242" y="122" width="36" height="36"></rect>
+              <circle cx="260" cy="140" r="5"></circle>
+            </g>
+          </svg>
+        </div>
+        <div class="archive-system-map__routes">
+          {
+            paths.map((path, index) => (
+              <span style={`--node-color:${path.accent}`}>
+                <b>0{index + 1}</b>
+                <em>{path.short}</em>
+              </span>
+            ))
+          }
         </div>
       </div>
     </div>
@@ -731,7 +771,8 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     background: color-mix(in srgb, var(--color-base-850) 72%, transparent);
   }
 
-  .archive-contributor-mark {
+  .archive-contributor-mark,
+  .archive-system-map {
     display: none;
   }
 
@@ -748,6 +789,10 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     --archive-line: #363930;
     --archive-copy: #9b9e95;
     --archive-meta: #85887f;
+    --archive-paper: #cdd3c9;
+    --archive-paper-ink: #11130f;
+    --archive-paper-muted: #444b42;
+    --archive-paper-line: #7c8578;
     --color-base-950: #090a08 !important;
     --color-base-900: #0d0e0c !important;
     --color-base-850: #11120f !important;
@@ -762,7 +807,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     --color-base-50: #f3f2ea !important;
     --color-term-green: #d7ff64 !important;
     --color-term-cyan: #8eb9aa !important;
-    --color-term-amber: #c7a76a !important;
+    --color-term-amber: #aeb9af !important;
     --color-term-red: #d87b68 !important;
     --color-term-violet: #a69abc !important;
     --color-term-blue: #86a7a0 !important;
@@ -906,76 +951,123 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   }
 
   :root[data-home-style="archive"] .terminal-object {
-    --color-base-950: #c7a76a !important;
-    --color-base-900: #c7a76a !important;
-    --color-base-850: #c7a76a !important;
-    --color-base-800: #b6975d !important;
-    --color-base-700: #6b5b3d !important;
-    --color-base-600: #4d422e !important;
-    --color-base-500: #50452f !important;
-    --color-base-400: #3f3829 !important;
-    --color-base-300: #29271f !important;
-    --color-base-200: #1b1b16 !important;
-    --color-base-100: #12130f !important;
-    --color-base-50: #090a08 !important;
-    --color-term-green: #11120f !important;
-    --color-term-blue: #2c5149 !important;
-    --color-term-amber: #7a3d2e !important;
     position: relative;
     min-height: 440px;
     overflow: hidden;
-    border: 1px solid #5e5037;
+    border: 1px solid #50564b;
     border-radius: 0 !important;
-    background: #c7a76a !important;
-    box-shadow: 16px 16px 0 #171914;
-    color: #11120f;
+    background: #0c0e0b !important;
+    box-shadow: 16px 16px 0 #151713;
+    color: #d7ff64;
   }
 
-  :root[data-home-style="archive"] .terminal-object::before,
-  :root[data-home-style="archive"] .terminal-object::after {
-    position: absolute;
-    z-index: 0;
-    border: 1px solid rgba(17, 18, 15, 0.22);
-    border-radius: 50%;
-    content: "";
-    pointer-events: none;
+  :root[data-home-style="archive"]
+    .terminal-object
+    > :is(.terminal-object__header, .terminal-object__body) {
+    display: none;
   }
 
-  :root[data-home-style="archive"] .terminal-object::before {
-    top: 18%;
-    right: 9%;
-    width: 250px;
-    height: 250px;
+  :root[data-home-style="archive"] .archive-system-map {
+    display: grid;
+    min-height: 438px;
+    grid-template-rows: auto minmax(0, 1fr) auto;
   }
 
-  :root[data-home-style="archive"] .terminal-object::after {
-    top: 23%;
-    right: -1%;
-    width: 250px;
-    height: 190px;
-  }
-
-  :root[data-home-style="archive"] .terminal-object > * {
-    position: relative;
-    z-index: 1;
-  }
-
-  :root[data-home-style="archive"] .terminal-object__header {
-    min-height: 54px;
-    border-color: #6b5b3d !important;
-    background: transparent !important;
-    letter-spacing: 0.05em;
+  :root[data-home-style="archive"] .archive-system-map__header {
+    display: flex;
+    min-height: 52px;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--archive-line);
+    color: var(--archive-meta);
+    font: 0.62rem var(--font-mono);
+    letter-spacing: 0.12em;
     text-transform: uppercase;
   }
 
-  :root[data-home-style="archive"] .terminal-object__body {
-    display: flex;
-    min-height: 380px;
-    flex-direction: column;
-    justify-content: center;
-    background: transparent !important;
-    font-size: 0.76rem !important;
-    line-height: 1.9 !important;
+  :root[data-home-style="archive"] .archive-system-map__diagram {
+    position: relative;
+    display: grid;
+    min-height: 260px;
+    place-items: center;
+    overflow: hidden;
+    background-image:
+      linear-gradient(rgba(215, 255, 100, 0.035) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(215, 255, 100, 0.035) 1px, transparent 1px);
+    background-size: 32px 32px;
+  }
+
+  :root[data-home-style="archive"] .archive-system-map__diagram svg {
+    width: min(100%, 520px);
+    height: auto;
+    padding: 1.25rem;
+  }
+
+  :root[data-home-style="archive"] .archive-system-map__orbits {
+    fill: none;
+    stroke: #4f574b;
+    stroke-width: 1;
+    vector-effect: non-scaling-stroke;
+  }
+
+  :root[data-home-style="archive"] .archive-system-map__nodes {
+    fill: #0c0e0b;
+    stroke: #d7ff64;
+    stroke-width: 1.5;
+    vector-effect: non-scaling-stroke;
+  }
+
+  :root[data-home-style="archive"] .archive-system-map__core {
+    fill: #0c0e0b;
+    stroke: #d7ff64;
+    stroke-width: 1.5;
+    vector-effect: non-scaling-stroke;
+  }
+
+  :root[data-home-style="archive"] .archive-system-map__core rect:first-child {
+    transform: rotate(45deg);
+    transform-origin: center;
+    transform-box: fill-box;
+  }
+
+  :root[data-home-style="archive"]
+    .archive-system-map__core
+    :is(rect:last-of-type, circle) {
+    fill: #d7ff64;
+  }
+
+  :root[data-home-style="archive"] .archive-system-map__routes {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    border-top: 1px solid var(--archive-line);
+    border-left: 1px solid var(--archive-line);
+  }
+
+  :root[data-home-style="archive"] .archive-system-map__routes > span {
+    display: grid;
+    min-width: 0;
+    grid-template-columns: auto 1fr;
+    gap: 0.55rem;
+    padding: 0.72rem;
+    border-right: 1px solid var(--archive-line);
+    border-bottom: 1px solid var(--archive-line);
+    font: 0.6rem var(--font-mono);
+    letter-spacing: 0.035em;
+  }
+
+  :root[data-home-style="archive"] .archive-system-map__routes b {
+    color: var(--node-color);
+    font-weight: 600;
+  }
+
+  :root[data-home-style="archive"] .archive-system-map__routes em {
+    overflow: hidden;
+    color: #a8aaa2;
+    font-style: normal;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   :root[data-home-style="archive"] [data-resume] {
@@ -1787,10 +1879,10 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
 
   :root[data-home-style="archive"] [data-portfolio-roadmap] {
     min-height: 390px;
-    border-color: #5e5037 !important;
+    border-color: var(--archive-paper-line) !important;
     border-radius: 0 !important;
-    background: #c7a76a !important;
-    color: #11120f;
+    background: var(--archive-paper) !important;
+    color: var(--archive-paper-ink);
   }
 
   :root[data-home-style="archive"] [data-portfolio-roadmap]::before,
@@ -1844,7 +1936,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   }
 
   :root[data-home-style="archive"] [data-portfolio-roadmap] h3 + p {
-    color: #3f3829 !important;
+    color: var(--archive-paper-muted) !important;
     font-size: 0.75rem;
     line-height: 1.55;
   }
@@ -1864,7 +1956,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     > div {
     border: 0;
     border-radius: 0;
-    background: rgba(199, 167, 106, 0.92);
+    background: color-mix(in srgb, var(--archive-paper) 94%, white);
   }
 
   :root[data-home-style="archive"] #quien > .grid {
@@ -1952,10 +2044,10 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   }
 
   :root[data-home-style="archive"] [data-community-panel] {
-    border-color: #5e5037 !important;
+    border-color: var(--archive-paper-line) !important;
     border-radius: 0 !important;
-    background: #c7a76a !important;
-    color: #11120f;
+    background: var(--archive-paper) !important;
+    color: var(--archive-paper-ink);
   }
 
   :root[data-home-style="archive"] [data-community-panel] img {
@@ -1969,8 +2061,8 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     > div:first-child
     > span {
     border-radius: 0;
-    background: #11120f;
-    color: #c7a76a;
+    background: var(--archive-paper-ink);
+    color: var(--archive-paper);
   }
 
   :root[data-home-style="archive"] [data-community-panel] h2 {
@@ -1992,7 +2084,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     > div
     > div:nth-child(2)
     > div:first-child {
-    color: #3f3829 !important;
+    color: var(--archive-paper-muted) !important;
   }
 
   :root[data-home-style="archive"] [data-community-panel] .btn-primary,
@@ -2005,8 +2097,8 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   }
 
   :root[data-home-style="archive"] [data-community-panel] .btn-primary {
-    background: #11120f;
-    color: #c7a76a;
+    background: var(--archive-paper-ink);
+    color: var(--archive-paper);
   }
 
   :root[data-home-style="archive"] body > footer {
@@ -2052,12 +2144,29 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
 
     :root[data-home-style="archive"] .terminal-object {
       min-height: 400px;
-      box-shadow: 9px 9px 0 #171914;
+      box-shadow: 9px 9px 0 #151713;
     }
 
-    :root[data-home-style="archive"] .terminal-object__body {
-      min-height: 340px;
-      font-size: 0.7rem !important;
+    :root[data-home-style="archive"] .archive-system-map {
+      min-height: 398px;
+    }
+
+    :root[data-home-style="archive"] .archive-system-map__header {
+      font-size: 0.56rem;
+    }
+
+    :root[data-home-style="archive"] .archive-system-map__diagram {
+      min-height: 230px;
+    }
+
+    :root[data-home-style="archive"] .archive-system-map__diagram svg {
+      padding: 0.75rem;
+    }
+
+    :root[data-home-style="archive"] .archive-system-map__routes > span {
+      gap: 0.4rem;
+      padding: 0.62rem 0.5rem;
+      font-size: 0.55rem;
     }
 
     :root[data-home-style="archive"] [data-trust-card] {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -103,6 +103,18 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
 ---
 
 <BaseLayout title="Open Security Labs" width="wide">
+  <script is:inline>
+    (() => {
+      let style = "current";
+      try {
+        if (localStorage.getItem("osl:home-style-v1") === "archive") {
+          style = "archive";
+        }
+      } catch {}
+      document.documentElement.dataset.homeStyle = style;
+    })();
+  </script>
+
   <!-- Grilla ambiental + glow radial verde detrás del hero (decorativos). -->
   <div
     class="bg-grid pointer-events-none fixed inset-0 -z-10"
@@ -272,7 +284,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     <div class="grid gap-3 sm:grid-cols-3">
       {
         trust.map((item) => (
-          <div class="card flex gap-3 p-4">
+          <div data-trust-card class="card flex gap-3 p-4">
             <span class="text-term-green mt-0.5 inline-flex shrink-0">
               <Icon name={item.icon} size={19} strokeWidth={1.7} />
             </span>
@@ -294,6 +306,9 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   <section id="metodo" class="scroll-mt-20 py-8">
     <div class="mb-2 flex items-baseline gap-3.5">
       <span class="text-term-green font-mono text-sm">// 01</span>
+      <span class="section-heading-icon" data-section-icon>
+        <Icon name="workflow" size={17} strokeWidth={1.7} />
+      </span>
       <h2 class="text-base-50 font-mono text-3xl font-bold tracking-tight">
         Cómo funciona un lab
       </h2>
@@ -307,6 +322,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
       {
         method.map((m) => (
           <div
+            data-method-card
             class="card p-5 hover:-translate-y-1"
             style={`--accent:${m.accent}; ${m.accent.includes("amber") ? "border-color: color-mix(in srgb, var(--color-term-amber) 40%, transparent);" : ""}`}
           >
@@ -332,6 +348,9 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   <section id="rutas" class="scroll-mt-20 py-8">
     <div class="mb-2 flex items-baseline gap-3.5">
       <span class="text-term-green font-mono text-sm">// 02</span>
+      <span class="section-heading-icon" data-section-icon>
+        <Icon name="git-branch" size={17} strokeWidth={1.7} />
+      </span>
       <h2 class="text-base-50 font-mono text-3xl font-bold tracking-tight">
         Rutas de aprendizaje
       </h2>
@@ -360,6 +379,9 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   <section id="certificaciones" class="scroll-mt-20 py-8">
     <div class="mb-2 flex items-baseline gap-3.5">
       <span class="text-term-green font-mono text-sm">// 03</span>
+      <span class="section-heading-icon" data-section-icon>
+        <Icon name="award" size={17} strokeWidth={1.7} />
+      </span>
       <h2 class="text-base-50 font-mono text-3xl font-bold tracking-tight">
         Certificaciones
       </h2>
@@ -384,6 +406,9 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   <section id="portafolio" class="scroll-mt-20 py-8">
     <div class="mb-2 flex items-baseline gap-3.5">
       <span class="text-term-green font-mono text-sm">// 04</span>
+      <span class="section-heading-icon" data-section-icon>
+        <Icon name="file-text" size={17} strokeWidth={1.7} />
+      </span>
       <h2 class="text-base-50 font-mono text-3xl font-bold tracking-tight">
         Proyectos para portafolio
       </h2>
@@ -398,6 +423,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
         {
           portfolioTeaser.map((project) => (
             <a
+              data-portfolio-project
               href={`/portafolio/#${project.slug}`}
               class="card group flex gap-4 p-4 hover:-translate-y-0.5"
               style={`--accent: ${project.accent}`}
@@ -429,6 +455,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
       </div>
 
       <div
+        data-portfolio-roadmap
         class="border-base-700 bg-base-900 relative overflow-hidden rounded-2xl border p-6 sm:p-7"
       >
         <div
@@ -480,6 +507,9 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   <section id="quien" class="scroll-mt-20 py-8">
     <div class="mb-2 flex items-baseline gap-3.5">
       <span class="text-term-green font-mono text-sm">// 05</span>
+      <span class="section-heading-icon" data-section-icon>
+        <Icon name="target" size={17} strokeWidth={1.7} />
+      </span>
       <h2 class="text-base-50 font-mono text-3xl font-bold tracking-tight">
         ¿Para quién es?
       </h2>
@@ -492,7 +522,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     <div class="grid gap-3.5 sm:grid-cols-2">
       {
         audience.map((a) => (
-          <div class="card flex gap-4 p-5">
+          <div data-audience-card class="card flex gap-4 p-5">
             <span class="text-term-green mt-0.5 inline-flex shrink-0">
               <Icon name={a.icon} size={22} strokeWidth={1.6} />
             </span>
@@ -514,6 +544,7 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   <!-- ===================== COMUNIDAD / CTA ===================== -->
   <section id="comunidad" class="scroll-mt-20 py-8">
     <div
+      data-community-panel
       class="border-base-700 bg-base-900 relative overflow-hidden rounded-2xl border p-8 sm:p-11"
     >
       <div
@@ -535,9 +566,12 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
         </div>
         <div>
           <div
-            class="text-term-green mb-3 font-mono text-xs tracking-[0.15em] uppercase"
+            class="text-term-green mb-3 flex items-center gap-2.5 font-mono text-xs tracking-[0.15em] uppercase"
           >
-            // comunidad
+            <span class="section-heading-icon" data-section-icon>
+              <Icon name="network" size={17} strokeWidth={1.7} />
+            </span>
+            <span>// comunidad</span>
           </div>
           <h2
             class="text-base-50 mb-3 font-mono text-2xl font-extrabold tracking-tight sm:text-3xl"
@@ -624,4 +658,1399 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
 
   render();
   onProgress(render);
+
+  type HomeStyle = "current" | "archive";
+  const homeStyleToggle = document.querySelector<HTMLButtonElement>(
+    "[data-home-style-toggle]",
+  );
+
+  function applyHomeStyle(style: HomeStyle, persist = true) {
+    document.documentElement.dataset.homeStyle = style;
+    const archiveIsActive = style === "archive";
+
+    if (homeStyleToggle) {
+      homeStyleToggle.setAttribute("aria-pressed", String(archiveIsActive));
+      homeStyleToggle.setAttribute(
+        "aria-label",
+        archiveIsActive
+          ? "Volver al estilo actual"
+          : "Activar estilo Archivo operativo",
+      );
+      homeStyleToggle.title = archiveIsActive
+        ? "Volver al estilo actual"
+        : "Activar Archivo operativo";
+    }
+
+    const themeColor = document.querySelector<HTMLMetaElement>(
+      'meta[name="theme-color"]',
+    );
+    if (themeColor) {
+      themeColor.content =
+        style === "archive"
+          ? "#090a08"
+          : document.documentElement.dataset.theme === "light"
+            ? "#ffffff"
+            : "#07090a";
+    }
+
+    if (persist) {
+      try {
+        localStorage.setItem("osl:home-style-v1", style);
+      } catch {}
+    }
+  }
+
+  homeStyleToggle?.addEventListener("click", () => {
+    applyHomeStyle(
+      document.documentElement.dataset.homeStyle === "archive"
+        ? "current"
+        : "archive",
+    );
+  });
+
+  applyHomeStyle(
+    document.documentElement.dataset.homeStyle === "archive"
+      ? "archive"
+      : "current",
+    false,
+  );
 </script>
+
+<style is:global>
+  .section-heading-icon {
+    display: inline-flex;
+    width: 2rem;
+    height: 2rem;
+    flex: none;
+    align-self: center;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--color-base-700);
+    border-radius: 0.45rem;
+    color: var(--color-term-green);
+    background: color-mix(in srgb, var(--color-base-850) 72%, transparent);
+  }
+
+  .archive-contributor-mark {
+    display: none;
+  }
+
+  [data-home-style-toggle][aria-pressed="true"] {
+    border-color: var(--color-term-green) !important;
+    color: var(--color-term-green) !important;
+    background: color-mix(in srgb, var(--color-term-green) 10%, transparent);
+  }
+
+  :root[data-home-style="archive"] {
+    color-scheme: dark;
+    --color-base-950: #090a08 !important;
+    --color-base-900: #0d0e0c !important;
+    --color-base-850: #11120f !important;
+    --color-base-800: #171914 !important;
+    --color-base-700: #2f322c !important;
+    --color-base-600: #44473f !important;
+    --color-base-500: #72766c !important;
+    --color-base-400: #8d9087 !important;
+    --color-base-300: #a8aaa2 !important;
+    --color-base-200: #cacbc4 !important;
+    --color-base-100: #e1e0d9 !important;
+    --color-base-50: #f3f2ea !important;
+    --color-term-green: #d7ff64 !important;
+    --color-term-cyan: #8eb9aa !important;
+    --color-term-amber: #c7a76a !important;
+    --color-term-red: #d87b68 !important;
+    --color-term-violet: #a69abc !important;
+    --color-term-blue: #86a7a0 !important;
+    --color-accent: #d7ff64 !important;
+  }
+
+  :root[data-home-style="archive"] body {
+    background: #090a08;
+  }
+
+  :root[data-home-style="archive"] body > header {
+    border-color: #2f322c !important;
+    background: rgba(9, 10, 8, 0.96) !important;
+    backdrop-filter: none;
+  }
+
+  :root[data-home-style="archive"] body > header > div {
+    height: 4.5rem;
+  }
+
+  :root[data-home-style="archive"] body > header img,
+  :root[data-home-style="archive"] body > header button,
+  :root[data-home-style="archive"] body > header a {
+    border-radius: 0 !important;
+  }
+
+  :root[data-home-style="archive"] body > header nav a {
+    color: #8d9087;
+    font-size: 0.65rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+
+  :root[data-home-style="archive"] body > header nav a[aria-current="page"] {
+    color: #d7ff64;
+  }
+
+  :root[data-home-style="archive"] [data-theme-toggle] {
+    display: none !important;
+  }
+
+  :root[data-home-style="archive"] .section-heading-icon {
+    border-color: #d7ff64;
+    border-radius: 0;
+    background: transparent;
+    color: #d7ff64;
+  }
+
+  :root[data-home-style="archive"] .bg-grid {
+    background-image:
+      linear-gradient(rgba(215, 255, 100, 0.035) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(215, 255, 100, 0.035) 1px, transparent 1px);
+    background-size: 56px 56px;
+    opacity: 0.65;
+  }
+
+  :root[data-home-style="archive"] .hero-frame {
+    grid-template-columns: minmax(0, 1.12fr) minmax(330px, 0.88fr) !important;
+    gap: clamp(3rem, 6vw, 5.5rem) !important;
+    min-height: 650px;
+    margin-top: 1rem !important;
+    padding: 4.5rem 0 5rem !important;
+    overflow: visible;
+    border: 0;
+    border-top: 1px solid #44473f;
+    border-bottom: 1px solid #44473f;
+    border-radius: 0;
+    background: transparent;
+  }
+
+  :root[data-home-style="archive"] .hero-frame::before {
+    display: none;
+  }
+
+  :root[data-home-style="archive"] .hero-frame h1 {
+    font-family: Georgia, "Times New Roman", serif !important;
+    font-size: clamp(3.6rem, 7vw, 6.8rem) !important;
+    font-weight: 400 !important;
+    line-height: 0.84 !important;
+    letter-spacing: -0.075em !important;
+  }
+
+  :root[data-home-style="archive"] .hero-frame h1 > span {
+    color: #d7ff64 !important;
+    font-style: italic;
+  }
+
+  :root[data-home-style="archive"] .hero-frame h1 + p {
+    max-width: 610px;
+    color: #a8aaa2;
+    font-size: 1rem;
+    line-height: 1.75;
+  }
+
+  :root[data-home-style="archive"] .hero-token {
+    border-color: #44473f;
+    border-radius: 0;
+    background: transparent;
+    color: #8d9087;
+    font-size: 0.62rem;
+  }
+
+  :root[data-home-style="archive"] .hero-frame .btn-primary {
+    border: 1px solid #d7ff64;
+    border-radius: 0;
+    background: #d7ff64;
+    color: #090a08;
+    box-shadow: none;
+  }
+
+  :root[data-home-style="archive"]
+    .hero-frame
+    > div:first-child
+    > div:last-child {
+    padding-top: 1.2rem;
+    border-top: 1px solid #2f322c;
+    color: #72766c;
+  }
+
+  :root[data-home-style="archive"] .terminal-object {
+    --color-base-950: #c7a76a !important;
+    --color-base-900: #c7a76a !important;
+    --color-base-850: #c7a76a !important;
+    --color-base-800: #b6975d !important;
+    --color-base-700: #6b5b3d !important;
+    --color-base-600: #4d422e !important;
+    --color-base-500: #50452f !important;
+    --color-base-400: #3f3829 !important;
+    --color-base-300: #29271f !important;
+    --color-base-200: #1b1b16 !important;
+    --color-base-100: #12130f !important;
+    --color-base-50: #090a08 !important;
+    --color-term-green: #11120f !important;
+    --color-term-blue: #2c5149 !important;
+    --color-term-amber: #7a3d2e !important;
+    position: relative;
+    min-height: 480px;
+    overflow: hidden;
+    border: 1px solid #5e5037;
+    border-radius: 0 !important;
+    background: #c7a76a !important;
+    box-shadow: 16px 16px 0 #171914;
+    color: #11120f;
+  }
+
+  :root[data-home-style="archive"] .terminal-object::before,
+  :root[data-home-style="archive"] .terminal-object::after {
+    position: absolute;
+    z-index: 0;
+    border: 1px solid rgba(17, 18, 15, 0.22);
+    border-radius: 50%;
+    content: "";
+    pointer-events: none;
+  }
+
+  :root[data-home-style="archive"] .terminal-object::before {
+    top: 18%;
+    right: 9%;
+    width: 250px;
+    height: 250px;
+  }
+
+  :root[data-home-style="archive"] .terminal-object::after {
+    top: 23%;
+    right: -1%;
+    width: 250px;
+    height: 190px;
+  }
+
+  :root[data-home-style="archive"] .terminal-object > * {
+    position: relative;
+    z-index: 1;
+  }
+
+  :root[data-home-style="archive"] .terminal-object__header {
+    min-height: 54px;
+    border-color: #6b5b3d !important;
+    background: transparent !important;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+
+  :root[data-home-style="archive"] .terminal-object__body {
+    display: flex;
+    min-height: 420px;
+    flex-direction: column;
+    justify-content: center;
+    background: transparent !important;
+    font-size: 0.73rem !important;
+    line-height: 1.9 !important;
+  }
+
+  :root[data-home-style="archive"] [data-resume] {
+    margin-top: 1px;
+    border: 0;
+    border-bottom: 1px solid #44473f;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  :root[data-home-style="archive"] [data-resume]::before {
+    display: none;
+  }
+
+  :root[data-home-style="archive"] [data-resume-progress],
+  :root[data-home-style="archive"] [data-resume-bar] {
+    border-radius: 0;
+  }
+
+  :root[data-home-style="archive"] main > section:not(#top) {
+    padding-top: 4.25rem !important;
+    padding-bottom: 4.25rem !important;
+  }
+
+  :root[data-home-style="archive"]
+    :is(
+      #metodo,
+      #rutas,
+      #certificaciones,
+      #portafolio,
+      #quien,
+      #agradecimientos
+    )
+    > div:first-child {
+    margin-bottom: 0.5rem !important;
+    padding-top: 1rem;
+    border-top: 1px solid #5a5d53;
+  }
+
+  :root[data-home-style="archive"]
+    :is(
+      #metodo,
+      #rutas,
+      #certificaciones,
+      #portafolio,
+      #quien,
+      #agradecimientos
+    )
+    h2 {
+    font-family: Georgia, "Times New Roman", serif !important;
+    font-size: clamp(2rem, 4vw, 3rem) !important;
+    font-weight: 400 !important;
+    letter-spacing: -0.035em !important;
+  }
+
+  :root[data-home-style="archive"]
+    :is(
+      #metodo,
+      #rutas,
+      #certificaciones,
+      #portafolio,
+      #quien,
+      #agradecimientos
+    )
+    > div:first-child
+    > span {
+    color: #d7ff64;
+    font-size: 0.58rem;
+  }
+
+  :root[data-home-style="archive"]
+    :is(
+      #metodo,
+      #rutas,
+      #certificaciones,
+      #portafolio,
+      #quien,
+      #agradecimientos
+    )
+    > div:first-child
+    + p {
+    max-width: 700px;
+    margin-bottom: 2.5rem !important;
+    color: #8d9087;
+    font-size: 0.85rem;
+    line-height: 1.65;
+  }
+
+  :root[data-home-style="archive"] main .card {
+    border-color: #2f322c;
+    border-radius: 0 !important;
+    background: #0d0e0c;
+    box-shadow: none !important;
+  }
+
+  :root[data-home-style="archive"] main .card::before {
+    display: none;
+  }
+
+  :root[data-home-style="archive"] main .card:hover {
+    border-color: color-mix(in srgb, var(--accent, #d7ff64) 55%, #44473f);
+    background: #11120f;
+    transform: none !important;
+  }
+
+  :root[data-home-style="archive"] #confianza {
+    padding-top: 0 !important;
+    padding-bottom: 1rem !important;
+  }
+
+  :root[data-home-style="archive"] #confianza > div {
+    gap: 0;
+    border-top: 1px solid #44473f;
+    border-bottom: 1px solid #44473f;
+  }
+
+  :root[data-home-style="archive"] [data-trust-card] {
+    min-height: 145px;
+    padding: 1.2rem !important;
+    border: 0;
+    border-right: 1px solid #44473f;
+    background: transparent;
+  }
+
+  :root[data-home-style="archive"] [data-trust-card]:first-child {
+    padding-left: 0 !important;
+  }
+
+  :root[data-home-style="archive"] [data-trust-card]:last-child {
+    border-right: 0;
+  }
+
+  :root[data-home-style="archive"] [data-trust-card] > span:first-child {
+    position: relative;
+    display: grid;
+    width: 38px;
+    height: 38px;
+    place-items: center;
+    border: 1px solid #d7ff64;
+    color: #d7ff64;
+  }
+
+  :root[data-home-style="archive"] [data-trust-card] > span:first-child svg {
+    display: none;
+  }
+
+  :root[data-home-style="archive"] [data-trust-card] > span:first-child::before,
+  :root[data-home-style="archive"] [data-trust-card] > span:first-child::after {
+    position: absolute;
+    content: "";
+  }
+
+  :root[data-home-style="archive"]
+    [data-trust-card]:nth-child(1)
+    > span:first-child::before {
+    inset: 8px;
+    border: 1px solid currentColor;
+    transform: rotate(45deg);
+  }
+
+  :root[data-home-style="archive"]
+    [data-trust-card]:nth-child(2)
+    > span:first-child {
+    border-radius: 50%;
+  }
+
+  :root[data-home-style="archive"]
+    [data-trust-card]:nth-child(2)
+    > span:first-child::before {
+    inset: 10px 8px 6px;
+    border: 1px solid currentColor;
+  }
+
+  :root[data-home-style="archive"]
+    [data-trust-card]:nth-child(2)
+    > span:first-child::after {
+    top: 5px;
+    left: 13px;
+    width: 12px;
+    height: 12px;
+    border: 1px solid currentColor;
+    border-bottom: 0;
+    border-radius: 50% 50% 0 0;
+  }
+
+  :root[data-home-style="archive"]
+    [data-trust-card]:nth-child(3)
+    > span:first-child::before,
+  :root[data-home-style="archive"]
+    [data-trust-card]:nth-child(3)
+    > span:first-child::after {
+    right: 7px;
+    left: 7px;
+    height: 1px;
+    background: currentColor;
+  }
+
+  :root[data-home-style="archive"]
+    [data-trust-card]:nth-child(3)
+    > span:first-child::before {
+    top: 13px;
+  }
+
+  :root[data-home-style="archive"]
+    [data-trust-card]:nth-child(3)
+    > span:first-child::after {
+    bottom: 13px;
+  }
+
+  :root[data-home-style="archive"]
+    [data-trust-card]
+    > span:last-child
+    > span:first-child {
+    font-family: Georgia, "Times New Roman", serif !important;
+    font-size: 0.9rem;
+    font-weight: 400;
+  }
+
+  :root[data-home-style="archive"]
+    [data-trust-card]
+    > span:last-child
+    > span:last-child {
+    color: #7f8279;
+    font-size: 0.68rem;
+  }
+
+  :root[data-home-style="archive"] #metodo > .grid {
+    gap: 1px;
+    background: #2f322c;
+  }
+
+  :root[data-home-style="archive"] [data-method-card] {
+    min-height: 285px;
+    padding: 1rem !important;
+    border: 0 !important;
+  }
+
+  :root[data-home-style="archive"] [data-method-card] > div:first-child {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: start;
+  }
+
+  :root[data-home-style="archive"]
+    [data-method-card]
+    > div:first-child
+    > span:first-child {
+    position: relative;
+    grid-column: 1 / -1;
+    grid-row: 2;
+    display: grid;
+    width: 88px;
+    height: 88px;
+    place-items: center;
+    margin: 1.7rem auto;
+    border: 1px solid currentColor;
+  }
+
+  :root[data-home-style="archive"]
+    [data-method-card]
+    > div:first-child
+    > span:first-child
+    svg {
+    display: none;
+  }
+
+  :root[data-home-style="archive"]
+    [data-method-card]
+    > div:first-child
+    > span:first-child::before,
+  :root[data-home-style="archive"]
+    [data-method-card]
+    > div:first-child
+    > span:first-child::after {
+    position: absolute;
+    content: "";
+  }
+
+  :root[data-home-style="archive"]
+    [data-method-card]:nth-child(1)
+    > div:first-child
+    > span:first-child::before {
+    inset: 14px 24px;
+    border: 1px solid currentColor;
+  }
+
+  :root[data-home-style="archive"]
+    [data-method-card]:nth-child(1)
+    > div:first-child
+    > span:first-child::after {
+    inset: 25px 14px 25px 34px;
+    border: 1px solid currentColor;
+  }
+
+  :root[data-home-style="archive"]
+    [data-method-card]:nth-child(2)
+    > div:first-child
+    > span:first-child::before {
+    inset: 16px;
+    border: 1px solid currentColor;
+  }
+
+  :root[data-home-style="archive"]
+    [data-method-card]:nth-child(2)
+    > div:first-child
+    > span:first-child::after {
+    top: 37px;
+    right: 25px;
+    left: 25px;
+    height: 1px;
+    background: currentColor;
+    box-shadow: 0 13px 0 currentColor;
+  }
+
+  :root[data-home-style="archive"]
+    [data-method-card]:nth-child(3)
+    > div:first-child
+    > span:first-child {
+    border-radius: 50%;
+  }
+
+  :root[data-home-style="archive"]
+    [data-method-card]:nth-child(3)
+    > div:first-child
+    > span:first-child::before {
+    inset: 17px;
+    border: 1px solid currentColor;
+    border-radius: 50%;
+  }
+
+  :root[data-home-style="archive"]
+    [data-method-card]:nth-child(3)
+    > div:first-child
+    > span:first-child::after {
+    inset: 34px;
+    border-radius: 50%;
+    background: currentColor;
+  }
+
+  :root[data-home-style="archive"]
+    [data-method-card]:nth-child(4)
+    > div:first-child
+    > span:first-child::before {
+    inset: 13px 22px;
+    border: 1px solid currentColor;
+  }
+
+  :root[data-home-style="archive"]
+    [data-method-card]:nth-child(4)
+    > div:first-child
+    > span:first-child::after {
+    top: 34px;
+    right: 30px;
+    left: 30px;
+    height: 1px;
+    background: currentColor;
+    box-shadow: 0 14px 0 currentColor;
+  }
+
+  :root[data-home-style="archive"] [data-method-card] > div:nth-child(2) {
+    font-family: Georgia, "Times New Roman", serif !important;
+    font-size: 0.95rem;
+    font-weight: 400;
+  }
+
+  :root[data-home-style="archive"] [data-method-card] > p {
+    color: #777a71;
+    font-size: 0.67rem;
+    line-height: 1.55;
+  }
+
+  :root[data-home-style="archive"] #rutas > .grid {
+    gap: 1px;
+    background: #2f322c;
+  }
+
+  :root[data-home-style="archive"] #rutas [data-path-card] {
+    min-height: 420px;
+    padding: 1rem !important;
+    border: 0;
+    background: #0d0e0c;
+  }
+
+  :root[data-home-style="archive"] #rutas [data-path-card] > div:first-child {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: start;
+  }
+
+  :root[data-home-style="archive"]
+    #rutas
+    [data-path-card]
+    > div:first-child
+    > span:first-child {
+    position: relative;
+    grid-column: 1 / -1;
+    grid-row: 2;
+    display: block;
+    width: 120px;
+    height: 120px;
+    margin: 2.2rem auto;
+    border: 1px solid var(--accent) !important;
+    border-radius: 0 !important;
+    background: transparent !important;
+    color: var(--accent);
+  }
+
+  :root[data-home-style="archive"]
+    #rutas
+    [data-path-card]
+    > div:first-child
+    > span:first-child
+    svg {
+    display: none;
+  }
+
+  :root[data-home-style="archive"]
+    #rutas
+    [data-path-card]
+    > div:first-child
+    > span:first-child::before,
+  :root[data-home-style="archive"]
+    #rutas
+    [data-path-card]
+    > div:first-child
+    > span:first-child::after {
+    position: absolute;
+    content: "";
+  }
+
+  :root[data-home-style="archive"]
+    #rutas
+    [data-path-card]
+    > div:first-child
+    > span:nth-child(2) {
+    grid-column: 1 / -1;
+    grid-row: 1;
+    width: 100%;
+    justify-content: space-between;
+    color: #777a71;
+    font-size: 0.48rem;
+  }
+
+  :root[data-home-style="archive"]
+    #rutas
+    > .grid
+    > [data-path-card]:nth-of-type(1)
+    > div:first-child
+    > span:first-child {
+    transform: rotate(45deg) scale(0.78);
+  }
+
+  :root[data-home-style="archive"]
+    #rutas
+    > .grid
+    > [data-path-card]:nth-of-type(1)
+    > div:first-child
+    > span:first-child::before,
+  :root[data-home-style="archive"]
+    #rutas
+    > .grid
+    > [data-path-card]:nth-of-type(1)
+    > div:first-child
+    > span:first-child::after {
+    border: 1px solid currentColor;
+  }
+
+  :root[data-home-style="archive"]
+    #rutas
+    > .grid
+    > [data-path-card]:nth-of-type(1)
+    > div:first-child
+    > span:first-child::before {
+    inset: 20px;
+  }
+
+  :root[data-home-style="archive"]
+    #rutas
+    > .grid
+    > [data-path-card]:nth-of-type(1)
+    > div:first-child
+    > span:first-child::after {
+    inset: 42px;
+    background: currentColor;
+  }
+
+  :root[data-home-style="archive"]
+    #rutas
+    > .grid
+    > [data-path-card]:nth-of-type(2)
+    > div:first-child
+    > span:first-child {
+    border-radius: 50% !important;
+  }
+
+  :root[data-home-style="archive"]
+    #rutas
+    > .grid
+    > [data-path-card]:nth-of-type(2)
+    > div:first-child
+    > span:first-child::before,
+  :root[data-home-style="archive"]
+    #rutas
+    > .grid
+    > [data-path-card]:nth-of-type(2)
+    > div:first-child
+    > span:first-child::after {
+    border: 1px solid currentColor;
+    border-radius: 50%;
+  }
+
+  :root[data-home-style="archive"]
+    #rutas
+    > .grid
+    > [data-path-card]:nth-of-type(2)
+    > div:first-child
+    > span:first-child::before {
+    inset: 20px -12px;
+  }
+
+  :root[data-home-style="archive"]
+    #rutas
+    > .grid
+    > [data-path-card]:nth-of-type(2)
+    > div:first-child
+    > span:first-child::after {
+    inset: -12px 20px;
+  }
+
+  :root[data-home-style="archive"]
+    #rutas
+    > .grid
+    > [data-path-card]:nth-of-type(3)
+    > div:first-child
+    > span:first-child {
+    background-image:
+      linear-gradient(currentColor 1px, transparent 1px),
+      linear-gradient(90deg, currentColor 1px, transparent 1px) !important;
+    background-size: 33.333% 33.333% !important;
+  }
+
+  :root[data-home-style="archive"]
+    #rutas
+    > .grid
+    > [data-path-card]:nth-of-type(3)
+    > div:first-child
+    > span:first-child::before {
+    inset: 40px;
+    background: currentColor;
+  }
+
+  :root[data-home-style="archive"]
+    #rutas
+    > .grid
+    > [data-path-card]:nth-of-type(4)
+    > div:first-child
+    > span:first-child {
+    border: 0 !important;
+  }
+
+  :root[data-home-style="archive"]
+    #rutas
+    > .grid
+    > [data-path-card]:nth-of-type(4)
+    > div:first-child
+    > span:first-child::before {
+    top: 18px;
+    left: 8px;
+    width: 64px;
+    height: 64px;
+    border: 1px solid currentColor;
+    border-radius: 50%;
+    box-shadow:
+      42px 20px 0 -1px #0d0e0c,
+      42px 20px 0 0 currentColor;
+  }
+
+  :root[data-home-style="archive"]
+    #rutas
+    > .grid
+    > [data-path-card]:nth-of-type(4)
+    > div:first-child
+    > span:first-child::after {
+    right: 14px;
+    bottom: 8px;
+    width: 76px;
+    height: 52px;
+    border: 1px solid currentColor;
+    border-radius: 50%;
+  }
+
+  :root[data-home-style="archive"]
+    #rutas
+    > .grid
+    > [data-path-card]:nth-of-type(5)
+    > div:first-child
+    > span:first-child {
+    width: 100px;
+    height: 82px;
+    margin-top: 3.8rem;
+  }
+
+  :root[data-home-style="archive"]
+    #rutas
+    > .grid
+    > [data-path-card]:nth-of-type(5)
+    > div:first-child
+    > span:first-child::before {
+    top: -46px;
+    left: 24px;
+    width: 50px;
+    height: 48px;
+    border: 1px solid currentColor;
+    border-bottom: 0;
+    border-radius: 50% 50% 0 0;
+  }
+
+  :root[data-home-style="archive"]
+    #rutas
+    > .grid
+    > [data-path-card]:nth-of-type(5)
+    > div:first-child
+    > span:first-child::after {
+    top: 31px;
+    left: 46px;
+    width: 7px;
+    height: 25px;
+    background: currentColor;
+  }
+
+  :root[data-home-style="archive"]
+    #rutas
+    > .grid
+    > [data-path-card]:nth-of-type(6)
+    > div:first-child
+    > span:first-child {
+    border: 0 !important;
+    background:
+      radial-gradient(circle at 50% 0, currentColor 0 6px, transparent 7px),
+      radial-gradient(circle at 100% 50%, currentColor 0 6px, transparent 7px),
+      radial-gradient(circle at 50% 100%, currentColor 0 6px, transparent 7px),
+      radial-gradient(circle at 0 50%, currentColor 0 6px, transparent 7px) !important;
+  }
+
+  :root[data-home-style="archive"]
+    #rutas
+    > .grid
+    > [data-path-card]:nth-of-type(6)
+    > div:first-child
+    > span:first-child::before {
+    top: 50%;
+    right: 0;
+    left: 0;
+    height: 1px;
+    background: currentColor;
+  }
+
+  :root[data-home-style="archive"]
+    #rutas
+    > .grid
+    > [data-path-card]:nth-of-type(6)
+    > div:first-child
+    > span:first-child::after {
+    top: 0;
+    bottom: 0;
+    left: 50%;
+    width: 1px;
+    background: currentColor;
+  }
+
+  :root[data-home-style="archive"] #rutas [data-path-card] h3 {
+    margin-top: auto;
+    font-family: Georgia, "Times New Roman", serif;
+    font-size: 1.35rem;
+    font-weight: 400;
+  }
+
+  :root[data-home-style="archive"] #rutas [data-path-card] h3 + p {
+    min-height: 3.2em;
+    color: #9b9e95;
+    font:
+      0.72rem/1.5 Georgia,
+      serif;
+  }
+
+  :root[data-home-style="archive"]
+    #rutas
+    [data-path-card]
+    > div:nth-of-type(2)
+    span {
+    border-color: #2f322c;
+    border-radius: 0;
+    background: transparent;
+    color: #72766c;
+    font-size: 0.5rem;
+  }
+
+  :root[data-home-style="archive"]
+    #rutas
+    [data-path-card]
+    > div:nth-of-type(3) {
+    border-color: #2f322c;
+    font-size: 0.55rem;
+  }
+
+  :root[data-home-style="archive"] #certificaciones > .grid {
+    gap: 1px;
+    background: #2f322c;
+  }
+
+  :root[data-home-style="archive"] #certificaciones .card {
+    min-height: 310px;
+    padding: 1rem !important;
+    border: 0;
+  }
+
+  :root[data-home-style="archive"]
+    #certificaciones
+    .card
+    > div:first-child
+    > span {
+    width: 4.4rem;
+    height: 4.4rem;
+    border-radius: 0 !important;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  :root[data-home-style="archive"] #certificaciones .card h3 {
+    font-family: Georgia, "Times New Roman", serif;
+    font-size: 1rem;
+    font-weight: 400;
+  }
+
+  :root[data-home-style="archive"] #certificaciones .card h3 + p {
+    color: #7f8279;
+    font-size: 0.68rem;
+    line-height: 1.55;
+  }
+
+  :root[data-home-style="archive"] #certificaciones .card > div:nth-of-type(2) {
+    gap: 1px;
+    background: #2f322c;
+  }
+
+  :root[data-home-style="archive"]
+    #certificaciones
+    .card
+    > div:nth-of-type(2)
+    > span {
+    border: 0;
+    border-radius: 0;
+    background: #11120f;
+    font-size: 0.5rem;
+  }
+
+  :root[data-home-style="archive"] #certificaciones .card > div:last-child {
+    border-color: #2f322c;
+    color: #72766c;
+    font-size: 0.53rem;
+  }
+
+  :root[data-home-style="archive"] #portafolio > div:nth-of-type(2) {
+    gap: 1.5rem;
+  }
+
+  :root[data-home-style="archive"] [data-portfolio-project] {
+    min-height: 120px;
+    padding: 1rem !important;
+    border: 0;
+    border-bottom: 1px solid #44473f;
+    background: transparent;
+  }
+
+  :root[data-home-style="archive"] [data-portfolio-project] > span:first-child {
+    border-radius: 0 !important;
+    background: transparent !important;
+  }
+
+  :root[data-home-style="archive"]
+    [data-portfolio-project]
+    > span:last-child
+    > span:nth-child(2) {
+    font-family: Georgia, "Times New Roman", serif;
+    font-size: 0.9rem;
+    font-weight: 400;
+  }
+
+  :root[data-home-style="archive"]
+    [data-portfolio-project]
+    > span:last-child
+    > span:last-child {
+    color: #777a71;
+    font-size: 0.67rem;
+    line-height: 1.5;
+  }
+
+  :root[data-home-style="archive"] #portafolio .btn-primary {
+    border-radius: 0;
+    background: #d7ff64;
+    color: #090a08;
+  }
+
+  :root[data-home-style="archive"] [data-portfolio-roadmap] {
+    min-height: 430px;
+    border-color: #5e5037 !important;
+    border-radius: 0 !important;
+    background: #c7a76a !important;
+    color: #11120f;
+  }
+
+  :root[data-home-style="archive"] [data-portfolio-roadmap]::before,
+  :root[data-home-style="archive"] [data-portfolio-roadmap]::after {
+    position: absolute;
+    border: 1px solid rgba(17, 18, 15, 0.28);
+    content: "";
+  }
+
+  :root[data-home-style="archive"] [data-portfolio-roadmap]::before {
+    top: 3.5rem;
+    right: 3rem;
+    width: 130px;
+    height: 130px;
+    transform: rotate(45deg);
+  }
+
+  :root[data-home-style="archive"] [data-portfolio-roadmap]::after {
+    top: 5.3rem;
+    right: 4.8rem;
+    width: 72px;
+    height: 72px;
+    background: rgba(17, 18, 15, 0.08);
+    transform: rotate(45deg);
+  }
+
+  :root[data-home-style="archive"] [data-portfolio-roadmap] > div:first-child {
+    display: none;
+  }
+
+  :root[data-home-style="archive"] [data-portfolio-roadmap] > div:last-child {
+    z-index: 1;
+    display: flex;
+    min-height: 370px;
+    flex-direction: column;
+  }
+
+  :root[data-home-style="archive"] [data-portfolio-roadmap] p,
+  :root[data-home-style="archive"] [data-portfolio-roadmap] h3,
+  :root[data-home-style="archive"] [data-portfolio-roadmap] span {
+    color: #11120f !important;
+  }
+
+  :root[data-home-style="archive"] [data-portfolio-roadmap] h3 {
+    max-width: 300px;
+    margin-top: auto;
+    font-family: Georgia, "Times New Roman", serif;
+    font-size: 1.8rem;
+    font-weight: 400;
+    line-height: 1;
+  }
+
+  :root[data-home-style="archive"] [data-portfolio-roadmap] h3 + p {
+    color: #3f3829 !important;
+    font-size: 0.69rem;
+  }
+
+  :root[data-home-style="archive"]
+    [data-portfolio-roadmap]
+    > div:last-child
+    > div:last-child {
+    gap: 1px;
+    background: rgba(17, 18, 15, 0.35);
+  }
+
+  :root[data-home-style="archive"]
+    [data-portfolio-roadmap]
+    > div:last-child
+    > div:last-child
+    > div {
+    border: 0;
+    border-radius: 0;
+    background: rgba(199, 167, 106, 0.92);
+  }
+
+  :root[data-home-style="archive"] #quien > .grid {
+    gap: 1px;
+    background: #2f322c;
+  }
+
+  :root[data-home-style="archive"] [data-audience-card] {
+    min-height: 150px;
+    padding: 1rem !important;
+    border: 0;
+  }
+
+  :root[data-home-style="archive"] [data-audience-card] > span:first-child {
+    display: grid;
+    width: 42px;
+    height: 42px;
+    place-items: center;
+    border: 1px solid #d7ff64;
+    color: #d7ff64;
+  }
+
+  :root[data-home-style="archive"]
+    [data-audience-card]
+    > div
+    > div:first-child {
+    font-family: Georgia, "Times New Roman", serif;
+    font-size: 0.98rem;
+    font-weight: 400;
+  }
+
+  :root[data-home-style="archive"] [data-audience-card] p {
+    color: #777a71;
+    font-size: 0.67rem;
+    line-height: 1.5;
+  }
+
+  :root[data-home-style="archive"] #agradecimientos > ul {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0;
+    border-top: 1px solid #2f322c;
+    border-left: 1px solid #2f322c;
+    background: transparent;
+  }
+
+  :root[data-home-style="archive"] #agradecimientos li .card {
+    min-height: 104px;
+    padding: 0.9rem !important;
+    border: 0;
+    border-right: 1px solid #2f322c;
+    border-bottom: 1px solid #2f322c;
+  }
+
+  :root[data-home-style="archive"] #agradecimientos li img {
+    display: none;
+  }
+
+  :root[data-home-style="archive"] .archive-contributor-mark {
+    display: grid;
+    width: 2.7rem;
+    height: 2.7rem;
+    flex: none;
+    place-items: center;
+    border: 1px solid #d7ff64;
+    color: #d7ff64;
+    font: 700 0.52rem var(--font-mono);
+  }
+
+  :root[data-home-style="archive"] #agradecimientos li .card p:first-child {
+    font-family: Georgia, "Times New Roman", serif;
+    font-size: 0.78rem;
+    font-weight: 400;
+  }
+
+  :root[data-home-style="archive"] #agradecimientos li .card p:last-child {
+    margin-top: 0.25rem;
+    color: #777a71;
+    font-size: 0.6rem;
+  }
+
+  :root[data-home-style="archive"] #comunidad {
+    padding-top: 2rem !important;
+  }
+
+  :root[data-home-style="archive"] [data-community-panel] {
+    border-color: #5e5037 !important;
+    border-radius: 0 !important;
+    background: #c7a76a !important;
+    color: #11120f;
+  }
+
+  :root[data-home-style="archive"] [data-community-panel] img {
+    border-color: #11120f !important;
+    border-radius: 50% !important;
+  }
+
+  :root[data-home-style="archive"]
+    [data-community-panel]
+    > div
+    > div:first-child
+    > span {
+    border-radius: 0;
+    background: #11120f;
+    color: #c7a76a;
+  }
+
+  :root[data-home-style="archive"] [data-community-panel] h2 {
+    color: #11120f !important;
+    font-family: Georgia, "Times New Roman", serif !important;
+    font-weight: 400 !important;
+  }
+
+  :root[data-home-style="archive"]
+    [data-community-panel]
+    .section-heading-icon {
+    border-color: #11120f;
+    color: #11120f;
+  }
+
+  :root[data-home-style="archive"] [data-community-panel] p,
+  :root[data-home-style="archive"]
+    [data-community-panel]
+    > div
+    > div:nth-child(2)
+    > div:first-child {
+    color: #3f3829 !important;
+  }
+
+  :root[data-home-style="archive"] [data-community-panel] .btn-primary,
+  :root[data-home-style="archive"] [data-community-panel] .btn-ghost {
+    border-color: #11120f;
+    border-radius: 0;
+    background: transparent;
+    color: #11120f;
+    box-shadow: none;
+  }
+
+  :root[data-home-style="archive"] [data-community-panel] .btn-primary {
+    background: #11120f;
+    color: #c7a76a;
+  }
+
+  :root[data-home-style="archive"] body > footer {
+    margin-top: 3rem !important;
+    border-color: #2f322c;
+    background: #0d0e0c;
+  }
+
+  :root[data-home-style="archive"] body > footer img {
+    border-radius: 50% !important;
+  }
+
+  :root[data-home-style="archive"] body > footer .rule-label {
+    color: #d7ff64;
+  }
+
+  @media (max-width: 1023px) {
+    :root[data-home-style="archive"] .hero-frame {
+      grid-template-columns: 1fr !important;
+    }
+
+    :root[data-home-style="archive"] .terminal-object {
+      max-width: 680px;
+    }
+
+    :root[data-home-style="archive"] #agradecimientos > ul {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @media (max-width: 640px) {
+    :root[data-home-style="archive"] main > section:not(#top) {
+      padding-top: 3.5rem !important;
+      padding-bottom: 3.5rem !important;
+    }
+
+    :root[data-home-style="archive"] .hero-frame {
+      margin-inline: -1.25rem;
+      padding: 3.5rem 1.25rem 4rem !important;
+      border-right: 0;
+      border-left: 0;
+    }
+
+    :root[data-home-style="archive"] .terminal-object {
+      min-height: 440px;
+      box-shadow: 9px 9px 0 #171914;
+    }
+
+    :root[data-home-style="archive"] .terminal-object__body {
+      min-height: 380px;
+      font-size: 0.65rem !important;
+    }
+
+    :root[data-home-style="archive"] [data-trust-card] {
+      border-right: 0;
+      border-bottom: 1px solid #44473f;
+      padding-left: 0 !important;
+    }
+
+    :root[data-home-style="archive"] [data-method-card] {
+      min-height: 250px;
+    }
+
+    :root[data-home-style="archive"] #rutas [data-path-card] {
+      min-height: 390px;
+    }
+
+    :root[data-home-style="archive"] [data-portfolio-roadmap] {
+      min-height: 400px;
+    }
+
+    :root[data-home-style="archive"] [data-community-panel] {
+      margin-inline: -1.25rem;
+      padding: 2rem 1.25rem !important;
+      border-right: 0;
+      border-left: 0;
+    }
+
+    :root[data-home-style="archive"] #agradecimientos > ul {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -771,7 +771,6 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
     background: color-mix(in srgb, var(--color-base-850) 72%, transparent);
   }
 
-  .archive-contributor-mark,
   .archive-system-map {
     display: none;
   }
@@ -2063,20 +2062,14 @@ const discord = "https://discord.com/invite/z6cr5JF6bJ";
   }
 
   :root[data-home-style="archive"] #agradecimientos li img {
-    display: none;
-  }
-
-  :root[data-home-style="archive"] .archive-contributor-mark {
-    display: grid;
+    display: block;
     width: 2.7rem;
     height: 2.7rem;
     flex: none;
-    place-items: center;
     border: 1px solid #5a5d53;
-    background: rgba(215, 255, 100, 0.04);
-    color: #d7ff64;
-    font: 700 0.68rem var(--font-mono);
-    letter-spacing: 0.04em;
+    border-radius: 0 !important;
+    filter: grayscale(1) contrast(1.05);
+    opacity: 0.92;
   }
 
   :root[data-home-style="archive"] #agradecimientos li .card p:first-child {


### PR DESCRIPTION
## Summary
- Add a compact homepage topbar control for the optional Archivo operativo skin, persisted in localStorage.
- Restyle the existing homepage DOM with responsive archive typography, layouts, section icons, and route symbols.
- Use an initials-based contributor grid in Archive mode while preserving the current homepage as the default presentation.

## Validation
- `npm run check`
- `npm run build`
- `git diff --check`
- Browser audit at 1440px and 390px with no horizontal overflow